### PR TITLE
Added alert policy module

### DIFF
--- a/terraform/alert_policy/missing_metric/main.tf
+++ b/terraform/alert_policy/missing_metric/main.tf
@@ -1,4 +1,4 @@
-resource "google_monitoring_alert_policy" "pararius_legacy_data_alert_policy" {
+resource "google_monitoring_alert_policy" "missing_metric" {
   display_name = "${var.display_name} (branch suffix: ${var.branch_suffix})"
   combiner     = "OR"
   enabled      = var.enabled

--- a/terraform/alert_policy/missing_metric/main.tf
+++ b/terraform/alert_policy/missing_metric/main.tf
@@ -1,0 +1,23 @@
+resource "google_monitoring_alert_policy" "pararius_legacy_data_alert_policy" {
+  display_name = "${var.display_name} (branch suffix: ${var.branch_suffix})"
+  combiner     = "OR"
+  enabled      = var.enabled
+  conditions {
+    display_name = var.condition_display_name
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/${var.logging_metric_name}\" AND resource.type=\"gcs_bucket\""
+      threshold_value = 1
+      duration        = "0s"
+      comparison      = "COMPARISON_LT"
+      aggregations {
+        alignment_period     = var.alignment_period
+        cross_series_reducer = "REDUCE_NONE"
+        per_series_aligner   = "ALIGN_DELTA"
+      }
+      trigger {
+        count = 1
+      }
+    }
+  }
+  notification_channels = [var.notification_channel_name]
+}

--- a/terraform/alert_policy/missing_metric/main.tf
+++ b/terraform/alert_policy/missing_metric/main.tf
@@ -1,5 +1,5 @@
 resource "google_monitoring_alert_policy" "missing_metric" {
-  display_name = "${var.display_name} (branch suffix: ${var.branch_suffix})"
+  display_name = var.display_name
   combiner     = "OR"
   enabled      = var.enabled
   conditions {

--- a/terraform/alert_policy/missing_metric/outputs.tf
+++ b/terraform/alert_policy/missing_metric/outputs.tf
@@ -1,0 +1,3 @@
+output "alert_policy_name" {
+  value = google_monitoring_alert_policy.missing_metric.name
+}

--- a/terraform/alert_policy/missing_metric/variables.tf
+++ b/terraform/alert_policy/missing_metric/variables.tf
@@ -6,7 +6,4 @@ variable "enabled" {
   default = true
 }
 variable "logging_metric_name" {}
-variable "method" {
-  default = "storage.objects.create"
-}
 variable "notification_channel_name" {}

--- a/terraform/alert_policy/missing_metric/variables.tf
+++ b/terraform/alert_policy/missing_metric/variables.tf
@@ -1,5 +1,4 @@
 variable "alignment_period" {}
-variable "branch_suffix" {}
 variable "condition_display_name" {}
 variable "display_name" {}
 variable "enabled" {

--- a/terraform/alert_policy/missing_metric/variables.tf
+++ b/terraform/alert_policy/missing_metric/variables.tf
@@ -1,0 +1,14 @@
+variable "alignment_period" {}
+variable "branch_suffix" {}
+variable "condition_display_name" {}
+variable "display_name" {}
+variable "enabled" {
+  default = true
+}
+variable "logging_metric_name" {}
+variable "method" {
+  default = "storage.objects.create"
+}
+variable "name" {}
+variable "notification_channel_name" {}
+variable "prefix" {}

--- a/terraform/alert_policy/missing_metric/variables.tf
+++ b/terraform/alert_policy/missing_metric/variables.tf
@@ -9,6 +9,4 @@ variable "logging_metric_name" {}
 variable "method" {
   default = "storage.objects.create"
 }
-variable "name" {}
 variable "notification_channel_name" {}
-variable "prefix" {}


### PR DESCRIPTION
Moved from ingestors to here

Little bit unsure about the use of having external `enabled` variable vs doing an internal `branch_suffix == ''` check

At least I got rid of the `count` mess which makes output harder to grab (need to know a count is used to access vars like `foo_resource[index.count].var_name`)