### PR TITLE
Added pubsub function module

### DIFF
--- a/terraform/function/pubsub/main.tf
+++ b/terraform/function/pubsub/main.tf
@@ -23,19 +23,19 @@ resource "google_cloudfunctions_function" "function" {
 }
 
 resource "google_service_account" "cf_sa" {
-  project      = var.project_id
   account_id   = format("gsa-%s", substr(md5(format("%s%s", var.function_name, var.branch_suffix)), 0, 26))
   display_name = "Service account for ${var.function_name} (branch suffix: ${var.branch_suffix})"
+  project      = var.project_id
 }
 
 resource "google_project_iam_member" "cf_sa_pubsub" {
-  project = var.project_id
   member  = "serviceAccount:${google_service_account.cf_sa.email}"
+  project = var.project_id
   role    = "roles/pubsub.publisher"
 }
 
 resource "google_project_iam_member" "cf_sa_user" {
-  project = var.project_id
   member  = "serviceAccount:${google_service_account.cf_sa.email}"
+  project = var.project_id
   role    = "roles/iam.serviceAccountUser"
 }

--- a/terraform/function/pubsub/main.tf
+++ b/terraform/function/pubsub/main.tf
@@ -20,7 +20,6 @@ resource "google_cloudfunctions_function" "function" {
     event_type = var.event_type
     resource   = var.topic_id
   }
-
 }
 
 resource "google_service_account" "cf_sa" {

--- a/terraform/function/pubsub/main.tf
+++ b/terraform/function/pubsub/main.tf
@@ -1,6 +1,6 @@
 resource "google_storage_bucket_object" "functioncode" {
-  name   = "function_sources/${var.function_name}${var.branch_suffix}/source.zip"
   bucket = var.bucket_name
+  name   = format("function_sources/%s%s/source.zip", var.function_name, var.branch_suffix)
   source = var.path_to_zip_file
 }
 

--- a/terraform/function/pubsub/main.tf
+++ b/terraform/function/pubsub/main.tf
@@ -1,0 +1,33 @@
+resource "google_storage_bucket_object" "functioncode" {
+  name   = "function_sources/${var.function_name}${var.branch_suffix}/source.zip"
+  bucket = var.bucket_name
+  source = var.path_to_zip_file
+}
+
+resource "google_cloudfunctions_function" "function" {
+  project = var.project_id
+  # see https://github.com/hashicorp/terraform-provider-google/issues/1938#issuecomment-740532646
+  name = format("%s%s-%s", var.function_name, var.branch_suffix, substr(regex("(?:[a-zA-Z](?:[-_a-zA-Z0-9]{0,30}[a-zA-Z0-9])?)",
+  google_storage_bucket_object.functioncode.md5hash), 0, 10))
+  runtime = "python39"
+
+  available_memory_mb   = var.function_memory
+  source_archive_bucket = google_storage_bucket_object.functioncode.bucket
+  source_archive_object = google_storage_bucket_object.functioncode.name
+  entry_point           = "handler"
+
+  event_trigger {
+    event_type = "google.pubsub.topic.publish"
+    resource   = var.topic_id
+  }
+
+  service_account_email = google_service_account.cf_sa.email
+  environment_variables = var.function_env_vars
+  timeout               = var.timeout
+}
+
+resource "google_service_account" "cf_sa" {
+  project      = var.project_id
+  account_id   = format("gsa-%s", substr(md5(format("%s%s", var.function_name, var.branch_suffix)), 0, 26))
+  display_name = "Service account for ${var.function_name} (branch suffix: ${var.branch_suffix})"
+}

--- a/terraform/function/pubsub/main.tf
+++ b/terraform/function/pubsub/main.tf
@@ -5,29 +5,38 @@ resource "google_storage_bucket_object" "functioncode" {
 }
 
 resource "google_cloudfunctions_function" "function" {
-  project = var.project_id
-  # see https://github.com/hashicorp/terraform-provider-google/issues/1938#issuecomment-740532646
-  name = format("%s%s-%s", var.function_name, var.branch_suffix, substr(regex("(?:[a-zA-Z](?:[-_a-zA-Z0-9]{0,30}[a-zA-Z0-9])?)",
-  google_storage_bucket_object.functioncode.md5hash), 0, 10))
-  runtime = "python39"
-
   available_memory_mb   = var.function_memory
+  entry_point           = var.entry_point
+  environment_variables = var.function_env_vars
+  name                  = format("%s%s-%s", var.function_name, var.branch_suffix, substr(regex("(?:[a-zA-Z](?:[-_a-zA-Z0-9]{0,30}[a-zA-Z0-9])?)", google_storage_bucket_object.functioncode.md5hash), 0, 10)) # see https://github.com/hashicorp/terraform-provider-google/issues/1938#issuecomment-740532646
+  project               = var.project_id
+  runtime               = var.runtime
+  service_account_email = google_service_account.cf_sa.email
   source_archive_bucket = google_storage_bucket_object.functioncode.bucket
   source_archive_object = google_storage_bucket_object.functioncode.name
-  entry_point           = "handler"
+  timeout               = var.timeout
 
   event_trigger {
-    event_type = "google.pubsub.topic.publish"
+    event_type = var.event_type
     resource   = var.topic_id
   }
 
-  service_account_email = google_service_account.cf_sa.email
-  environment_variables = var.function_env_vars
-  timeout               = var.timeout
 }
 
 resource "google_service_account" "cf_sa" {
   project      = var.project_id
   account_id   = format("gsa-%s", substr(md5(format("%s%s", var.function_name, var.branch_suffix)), 0, 26))
   display_name = "Service account for ${var.function_name} (branch suffix: ${var.branch_suffix})"
+}
+
+resource "google_project_iam_member" "cf_sa_pubsub" {
+  project = var.project_id
+  member  = "serviceAccount:${google_service_account.cf_sa.email}"
+  role    = "roles/pubsub.publisher"
+}
+
+resource "google_project_iam_member" "cf_sa_user" {
+  project = var.project_id
+  member  = "serviceAccount:${google_service_account.cf_sa.email}"
+  role    = "roles/iam.serviceAccountUser"
 }

--- a/terraform/function/pubsub/outputs.tf
+++ b/terraform/function/pubsub/outputs.tf
@@ -1,0 +1,3 @@
+output "function_sa_email" {
+  value = google_service_account.cf_sa.email
+}

--- a/terraform/function/pubsub/variables.tf
+++ b/terraform/function/pubsub/variables.tf
@@ -7,7 +7,9 @@ variable "event_type" {
   default = "google.pubsub.topic.publish"
 }
 variable "function_env_vars" {}
-variable "function_memory" {}
+variable "function_memory" {
+  default = 128
+}
 variable "function_name" {}
 variable "path_to_zip_file" {}
 variable "project_id" {}

--- a/terraform/function/pubsub/variables.tf
+++ b/terraform/function/pubsub/variables.tf
@@ -1,0 +1,11 @@
+variable "bucket_name" {}
+variable "branch_suffix" {}
+variable "function_env_vars" {}
+variable "function_memory" {}
+variable "function_name" {}
+variable "path_to_zip_file" {}
+variable "project_id" {}
+variable "region" {}
+variable "source_code_root_path" {}
+variable "topic_id" {}
+variable "timeout" { default = 60 }

--- a/terraform/function/pubsub/variables.tf
+++ b/terraform/function/pubsub/variables.tf
@@ -1,11 +1,19 @@
-variable "bucket_name" {}
 variable "branch_suffix" {}
+variable "bucket_name" {}
+variable "entry_point" {
+  default = "handler"
+}
+variable "event_type" {
+  default = "google.pubsub.topic.publish"
+}
 variable "function_env_vars" {}
 variable "function_memory" {}
 variable "function_name" {}
 variable "path_to_zip_file" {}
 variable "project_id" {}
 variable "region" {}
-variable "source_code_root_path" {}
+variable "runtime" {
+  default = "python39"
+}
 variable "topic_id" {}
 variable "timeout" { default = 60 }


### PR DESCRIPTION
Still needs quite a lot of variables but at least it becomes reusable now

I have kept some role assignments in here that I think will always be needed (mainly `pubsub.publisher`), the idea being that projects now only have to add (optional) roles that are specific to what the function does. @barendregt forgot why we need the other role assigned (`serviceAccountUser`), do we still need it here?

Also decided to replace the `${var.source_code_root_path}/${var.function_name}/${var.function_name}.zip` source path with a more generic `path_to_zip_file` variable to make it less opinionated about how a project has structured its code (at the cost of being a little more verbose on the implementation side)