### PR TITLE
Shortened random value and used it for function naming

### DIFF
--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -8,7 +8,7 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb           = var.function_memory
   entry_point                   = var.function_entry_point
   environment_variables         = var.function_env_vars
-  name                          = format("%s%s", var.function_name, var.branch_suffix)
+  name                          = format("%s%s-%s", var.function_name, var.branch_suffix, random_string.random.result)
   project                       = var.project_id
   runtime                       = var.function_runtime
   service_account_email         = var.function_service_account_email
@@ -25,7 +25,7 @@ resource "google_cloudfunctions_function" "function" {
 }
 
 resource "random_string" "random" {
-  length           = 16
+  length           = 4
   special          = true
   override_special = "/@£$"
 }

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -26,8 +26,7 @@ resource "google_cloudfunctions_function" "function" {
 
 resource "random_string" "random" {
   length           = 4
-  special          = true
-  override_special = "/@£$"
+  special          = false
 }
 
 resource "google_storage_bucket_object" "functioncode" {

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -23,8 +23,7 @@ resource "google_cloudfunctions_function" "function" {
 
 resource "random_string" "random" {
   length           = 4
-  special          = true
-  override_special = "/@£$"
+  special          = false
 }
 
 resource "google_storage_bucket_object" "functioncode" {


### PR DESCRIPTION
reason for shortening the value is that it will have less chance of going over maximum function name size, and 4 seems enough entropy for us