### PR TITLE
Force function deployment every time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,11 @@ help: ## Show this help message.
 
 cs: ## Checks for code style issues
 	docker-compose run --rm python black --check .
+	terraform -chdir=terraform fmt -check -recursive .
 
 cs-fix: ## Fixes code style issues
 	docker-compose run --rm python black .
+	terraform -chdir=terraform fmt -recursive .
 
 build: ## Builds the image including the setup.py file (run this when you've changed dependencies)
 	docker-compose build python

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -8,7 +8,8 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb           = var.function_memory
   entry_point                   = var.function_entry_point
   environment_variables         = var.function_env_vars
-  name                          = format("%s%s-%s", var.function_name, var.branch_suffix, random_string.random.result)
+  labels                        = { last_deployed_at = timestamp() }
+  name                          = format("%s%s", var.function_name, var.branch_suffix)
   project                       = var.project_id
   runtime                       = var.function_runtime
   service_account_email         = var.function_service_account_email
@@ -24,13 +25,8 @@ resource "google_cloudfunctions_function" "function" {
   }
 }
 
-resource "random_string" "random" {
-  length           = 4
-  special          = false
-}
-
 resource "google_storage_bucket_object" "functioncode" {
-  name   = format("pubsub_function_sources/%s/sourcecode%s.zip", var.function_name, random_string.random.result)
+  name   = format("pubsub_function_sources/%s/sourcecode%s.zip", var.function_name, var.branch_suffix)
   bucket = var.source_code_bucket_name
   source = format("%s/%s/%s.zip", var.source_code_root_path, var.function_name, var.function_name)
 }

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -8,7 +8,7 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb           = var.function_memory
   entry_point                   = var.function_entry_point
   environment_variables         = var.function_env_vars
-  labels                        = { last_deployed_at = timestamp() }
+  labels                        = { last_deployed_at = tostring(timestamp()) }
   name                          = format("%s%s", var.function_name, var.branch_suffix)
   project                       = var.project_id
   runtime                       = var.function_runtime

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -5,10 +5,12 @@ Often used in conjunction with bucket notifications to act on objects created in
 */
 
 resource "google_cloudfunctions_function" "function" {
-  available_memory_mb           = var.function_memory
-  entry_point                   = var.function_entry_point
-  environment_variables         = var.function_env_vars
-  labels                        = { last_deployed_at = tostring(timestamp()) }
+  available_memory_mb   = var.function_memory
+  entry_point           = var.function_entry_point
+  environment_variables = var.function_env_vars
+  labels = {
+    last_deployed_at = "${timestamp()}"
+  }
   name                          = format("%s%s", var.function_name, var.branch_suffix)
   project                       = var.project_id
   runtime                       = var.function_runtime

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -3,17 +3,11 @@ Cloud Function triggered by a message published on a PubSub topic.
 
 Often used in conjunction with bucket notifications to act on objects created in a bucket.
 */
-locals {
-  # Due to a bug in terraform, GC functions are not (re)deployed even on code changes
-  # In our case we simply force it for every apply using a label with current timestamp as its value
-  renewable_labels = { last_deployed_at = formatdate("YYYYMMDDhhmmss", timestamp()) }
-}
-
 resource "google_cloudfunctions_function" "function" {
   available_memory_mb           = var.function_memory
   entry_point                   = var.function_entry_point
   environment_variables         = var.function_env_vars
-  labels                        = local.renewable_labels
+  labels                        = { last_deployed_at = formatdate("YYYYMMDDhhmmss", timestamp()) }
   name                          = format("%s%s", var.function_name, var.branch_suffix)
   project                       = var.project_id
   runtime                       = var.function_runtime

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -4,11 +4,17 @@ Cloud Function invoked by a scheduled job through a HTTP request
 Often used to do things that need to be executed at regular intervals,
 like pulling data from external sources or doing aggregations
 */
+locals {
+  # Due to a bug in terraform, GC functions are not (re)deployed even on code changes
+  # In our case we simply force it for every apply using a label with current timestamp as its value
+  renewable_labels = { last_deployed_at = formatdate("YYYYMMDDhhmmss", timestamp()) }
+}
+
 resource "google_cloudfunctions_function" "function" {
   available_memory_mb           = var.function_memory
   entry_point                   = var.function_entry_point
   environment_variables         = var.function_env_vars
-  labels                        = { last_deployed_at = tostring(timestamp()) }
+  labels                        = local.renewable_labels
   name                          = format("%s%s", var.function_name, var.branch_suffix)
   project                       = var.project_id
   region                        = var.project_region
@@ -25,6 +31,7 @@ resource "google_cloudfunctions_function" "function" {
 resource "google_storage_bucket_object" "functioncode" {
   name   = format("http_function_sources/%s/sourcecode%s.zip", var.function_name, var.branch_suffix)
   bucket = var.source_code_bucket_name
+  labels = local.renewable_labels
   source = "${var.source_code_root_path}/${var.function_name}/${var.function_name}.zip"
 }
 

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -8,7 +8,8 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb           = var.function_memory
   entry_point                   = var.function_entry_point
   environment_variables         = var.function_env_vars
-  name                          = format("%s%s-%s", var.function_name, var.branch_suffix, random_string.random.result)
+  labels                        = { last_deployed_at = timestamp() }
+  name                          = format("%s%s", var.function_name, var.branch_suffix)
   project                       = var.project_id
   region                        = var.project_region
   runtime                       = var.function_runtime
@@ -21,13 +22,8 @@ resource "google_cloudfunctions_function" "function" {
   vpc_connector_egress_settings = var.function_vpc_connector_egress_settings
 }
 
-resource "random_string" "random" {
-  length           = 4
-  special          = false
-}
-
 resource "google_storage_bucket_object" "functioncode" {
-  name   = format("http_function_sources/%s/sourcecode%s.zip", var.function_name, random_string.random.result)
+  name   = format("http_function_sources/%s/sourcecode%s.zip", var.function_name, var.branch_suffix)
   bucket = var.source_code_bucket_name
   source = "${var.source_code_root_path}/${var.function_name}/${var.function_name}.zip"
 }

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -29,7 +29,7 @@ resource "google_storage_bucket_object" "functioncode" {
 }
 
 resource "google_cloud_scheduler_job" "scheduler_job" {
-  for_each = {for scheduler in var.schedulers: scheduler.name => scheduler}
+  for_each = { for scheduler in var.schedulers : scheduler.name => scheduler }
 
   attempt_deadline = each.value.attempt_deadline != null ? each.value.attempt_deadline : "320s"
   name             = each.value.name
@@ -45,10 +45,10 @@ resource "google_cloud_scheduler_job" "scheduler_job" {
     http_method = each.value.request_method != null ? each.value.request_method : "POST"
 
     headers = {
-      "Content-Type": "application/json"
+      "Content-Type" : "application/json"
     }
 
-    uri         = google_cloudfunctions_function.function.https_trigger_url
+    uri = google_cloudfunctions_function.function.https_trigger_url
 
     oidc_token {
       service_account_email = var.scheduler_service_account_email

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -4,17 +4,11 @@ Cloud Function invoked by a scheduled job through a HTTP request
 Often used to do things that need to be executed at regular intervals,
 like pulling data from external sources or doing aggregations
 */
-locals {
-  # Due to a bug in terraform, GC functions are not (re)deployed even on code changes
-  # In our case we simply force it for every apply using a label with current timestamp as its value
-  renewable_labels = { last_deployed_at = formatdate("YYYYMMDDhhmmss", timestamp()) }
-}
-
 resource "google_cloudfunctions_function" "function" {
   available_memory_mb           = var.function_memory
   entry_point                   = var.function_entry_point
   environment_variables         = var.function_env_vars
-  labels                        = local.renewable_labels
+  labels                        = { last_deployed_at = formatdate("YYYYMMDDhhmmss", timestamp()) }
   name                          = format("%s%s", var.function_name, var.branch_suffix)
   project                       = var.project_id
   region                        = var.project_region
@@ -31,7 +25,6 @@ resource "google_cloudfunctions_function" "function" {
 resource "google_storage_bucket_object" "functioncode" {
   name   = format("http_function_sources/%s/sourcecode%s.zip", var.function_name, var.branch_suffix)
   bucket = var.source_code_bucket_name
-  labels = local.renewable_labels
   source = "${var.source_code_root_path}/${var.function_name}/${var.function_name}.zip"
 }
 

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -8,7 +8,7 @@ resource "google_cloudfunctions_function" "function" {
   available_memory_mb           = var.function_memory
   entry_point                   = var.function_entry_point
   environment_variables         = var.function_env_vars
-  labels                        = { last_deployed_at = timestamp() }
+  labels                        = { last_deployed_at = tostring(timestamp()) }
   name                          = format("%s%s", var.function_name, var.branch_suffix)
   project                       = var.project_id
   region                        = var.project_region

--- a/terraform/cloud_function/scheduled/variables.tf
+++ b/terraform/cloud_function/scheduled/variables.tf
@@ -32,11 +32,11 @@ variable "schedulers" {
   default = []
   type = list(object({
     attempt_deadline = optional(string)
-    name = string
-    schedule = string
-    request_body = optional(string)
-    request_method = optional(string)
-    retry_count = optional(number)
+    name             = string
+    schedule         = string
+    request_body     = optional(string)
+    request_method   = optional(string)
+    retry_count      = optional(number)
   }))
 }
 variable "source_code_bucket_name" {}


### PR DESCRIPTION
No need for random strings anymore, at least should allow us to work around the buggy function deploy

see 
https://github.com/hashicorp/terraform-provider-google/issues/4871#issuecomment-553194286
https://github.com/hashicorp/terraform-provider-google/issues/1938