### PR TITLE
Retry of selfzipping solution

### DIFF
--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -16,7 +16,7 @@ locals {
 
 # Compress source code
 data "archive_file" "source" {
-#  excludes    = local.excluded_files
+  excludes    = local.excluded_files
   output_path = format("/tmp/%s/pubsub_function_%s.zip", var.function_name, formatdate("YYMMDDhhmmss", timestamp()))
   source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
   type        = "zip"

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -9,7 +9,7 @@ locals {
     for srcFile in local.source_files :
     srcFile if contains(local.include_list, srcFile) == false
   ]) : []
-  include_list  = fileexists(abspath(format("%s/include.lst", local.source_prefix))) ? split("\n", file(format("%s/include.lst", local.source_prefix))) : []
+  include_list  = fileexists(format("%s/include.lst", local.source_prefix)) ? split("\n", file(format("%s/include.lst", local.source_prefix))) : []
   source_files  = fileset(local.source_prefix, "**")
   source_prefix = format("%s/%s", var.source_code_root_path, var.function_name)
 }

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -4,24 +4,37 @@ Cloud Function triggered by a message published on a PubSub topic.
 Often used in conjunction with bucket notifications to act on newly created objects.
 */
 
+locals {
+  excluded_files = length(local.include_list) > 0 ? toset([
+    for srcFile in local.source_files :
+    srcFile if contains(local.include_list, srcFile) == false
+  ]) : []
+  include_list  = fileexists(format("%s/include.lst", local.source_prefix)) ? split(file(format("%s/include.lst", local.source_prefix)), "\n") : []
+  source_files  = fileset(path.module, format("%s/*.*", local.source_prefix))
+  source_prefix = format("%s/%s", var.source_code_root_path, var.function_name)
+}
+
 # Compress source code
 data "archive_file" "source" {
-  type        = "zip"
-  source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
+  excludes    = local.excluded_files
   output_path = format("/tmp/%s/pubsub_function_%s.zip", var.function_name, formatdate("YYMMDDhhmmss", timestamp()))
+  source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
+  type        = "zip"
 }
 
 resource "google_storage_bucket_object" "functioncode" {
-  name   = format("pubsub_function_sources/%s/%s.zip", var.function_name, data.archive_file.source.output_md5)
+  name = format("pubsub_function_sources/%s/%s.zip", var.function_name, data.archive_file.source.output_md5)
+
   bucket = var.source_code_bucket_name
   source = data.archive_file.source.output_path
 }
 
 resource "google_cloudfunctions_function" "function" {
+  name = format("%s%s", var.function_name, var.branch_suffix)
+
   available_memory_mb           = var.function_memory
   entry_point                   = var.function_entry_point
   environment_variables         = var.function_env_vars
-  name                          = format("%s%s", var.function_name, var.branch_suffix)
   project                       = var.project_id
   runtime                       = var.function_runtime
   service_account_email         = var.function_service_account_email

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -9,8 +9,8 @@ locals {
     for srcFile in local.source_files :
     srcFile if contains(local.include_list, srcFile) == false
   ]) : []
-  include_list  = fileexists(abspath(format("%s/include.lst", local.source_prefix))) ? split(file(format("%s/include.lst", local.source_prefix)), "\n") : []
-  source_files  = fileset(local.source_prefix, "*")
+  include_list  = fileexists(abspath(format("%s/include.lst", local.source_prefix))) ? split("\n", file(format("%s/include.lst", local.source_prefix))) : []
+  source_files  = fileset(local.source_prefix, "**")
   source_prefix = format("%s/%s", var.source_code_root_path, var.function_name)
 }
 

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -51,9 +51,9 @@ resource "google_cloudfunctions_function" "function" {
 }
 
 output "excluded_files" {
-  value = join(local.excluded_files, ",")
+  value = join(",", local.excluded_files)
 }
 
 output "include_list" {
-  value = join(local.include_list, ",")
+  value = join(",", local.include_list)
 }

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -16,7 +16,7 @@ locals {
 
 # Compress source code
 data "archive_file" "source" {
-  excludes    = local.excluded_files
+#  excludes    = local.excluded_files
   output_path = format("/tmp/%s/pubsub_function_%s.zip", var.function_name, formatdate("YYMMDDhhmmss", timestamp()))
   source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
   type        = "zip"

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -3,12 +3,28 @@ Cloud Function triggered by a message published on a PubSub topic.
 
 Often used in conjunction with bucket notifications to act on objects created in a bucket.
 */
+locals {
+  timestamp = formatdate("YYMMDDhhmmss", timestamp())
+}
+
+# Compress source code
+data "archive_file" "source" {
+  type        = "zip"
+  source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
+  output_path = format("/tmp/pubsub_function_%s.zip", local.timestamp)
+}
+
+resource "google_storage_bucket_object" "functioncode" {
+  name   = format("pubsub_function_sources/%s/%s.zip", var.function_name, data.archive_file.source.output_md5)
+  bucket = var.source_code_bucket_name
+  source = data.archive_file.source.output_path
+}
+
 resource "google_cloudfunctions_function" "function" {
   available_memory_mb           = var.function_memory
   entry_point                   = var.function_entry_point
   environment_variables         = var.function_env_vars
-  labels                        = { last_deployed_at = formatdate("YYYYMMDDhhmmss", timestamp()) }
-  name                          = format("%s%s%s", var.function_name_prefix, var.function_name, var.branch_suffix)
+  name                          = format("%s%s", var.function_name, var.branch_suffix)
   project                       = var.project_id
   runtime                       = var.function_runtime
   service_account_email         = var.function_service_account_email
@@ -22,10 +38,4 @@ resource "google_cloudfunctions_function" "function" {
     event_type = "google.pubsub.topic.publish"
     resource   = var.pubsub_topic_id
   }
-}
-
-resource "google_storage_bucket_object" "functioncode" {
-  name   = format("pubsub_function_sources/%s%s/sourcecode%s.zip", var.function_name_prefix, var.function_name, var.branch_suffix)
-  bucket = var.source_code_bucket_name
-  source = format("%s/%s/%s.zip", var.source_code_root_path, var.function_name, var.function_name)
 }

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -1,17 +1,14 @@
 /*
 Cloud Function triggered by a message published on a PubSub topic.
 
-Often used in conjunction with bucket notifications to act on objects created in a bucket.
+Often used in conjunction with bucket notifications to act on newly created objects.
 */
-locals {
-  timestamp = formatdate("YYMMDDhhmmss", timestamp())
-}
 
 # Compress source code
 data "archive_file" "source" {
   type        = "zip"
   source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
-  output_path = format("/tmp/pubsub_function_%s.zip", local.timestamp)
+  output_path = format("/tmp/pubsub_function_%s.zip", formatdate("YYMMDDhhmmss", timestamp()))
 }
 
 resource "google_storage_bucket_object" "functioncode" {

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -9,8 +9,8 @@ locals {
     for srcFile in local.source_files :
     srcFile if contains(local.include_list, srcFile) == false
   ]) : []
-  include_list  = fileexists(format("%s/include.lst", local.source_prefix)) ? split(file(format("%s/include.lst", local.source_prefix)), "\n") : []
-  source_files  = fileset(path.module, format("%s/*.*", local.source_prefix))
+  include_list  = fileexists(abspath(format("%s/include.lst", local.source_prefix))) ? split(file(format("%s/include.lst", local.source_prefix)), "\n") : []
+  source_files  = fileset(local.source_prefix, "*")
   source_prefix = format("%s/%s", var.source_code_root_path, var.function_name)
 }
 

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -8,7 +8,7 @@ Often used in conjunction with bucket notifications to act on newly created obje
 data "archive_file" "source" {
   type        = "zip"
   source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
-  output_path = format("/tmp/pubsub_function_%s.zip", formatdate("YYMMDDhhmmss", timestamp()))
+  output_path = format("/tmp/%s/pubsub_function_%s.zip", var.function_name, formatdate("YYMMDDhhmmss", timestamp()))
 }
 
 resource "google_storage_bucket_object" "functioncode" {

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -49,3 +49,11 @@ resource "google_cloudfunctions_function" "function" {
     resource   = var.pubsub_topic_id
   }
 }
+
+output "excluded_files" {
+  value = join(local.excluded_files, ",")
+}
+
+output "include_list" {
+  value = join(local.include_list, ",")
+}

--- a/terraform/cloud_function/pubsub_triggered/main.tf
+++ b/terraform/cloud_function/pubsub_triggered/main.tf
@@ -49,11 +49,3 @@ resource "google_cloudfunctions_function" "function" {
     resource   = var.pubsub_topic_id
   }
 }
-
-output "excluded_files" {
-  value = join(",", local.excluded_files)
-}
-
-output "include_list" {
-  value = join(",", local.include_list)
-}

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -17,7 +17,7 @@ locals {
 
 # Compress source code
 data "archive_file" "source" {
-#  excludes    = local.excluded_files
+  excludes    = local.excluded_files
   output_path = format("/tmp/%s/http_function_%s.zip", var.function_name, formatdate("YYMMDDhhmmss", timestamp()))
   source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
   type        = "zip"

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -11,7 +11,7 @@ locals {
     srcFile if contains(local.include_list, srcFile) == false
   ]) : []
   include_list  = fileexists(format("%s/include.lst", local.source_prefix)) ? split(file(format("%s/include.lst", local.source_prefix)), "\n") : []
-  source_files  = fileset(path.module, format("%s/%s/*.*", local.source_prefix))
+  source_files  = fileset(path.module, format("%s/*.*", local.source_prefix))
   source_prefix = format("%s/%s", var.source_code_root_path, var.function_name)
 }
 

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -11,7 +11,7 @@ locals {
     srcFile if contains(local.include_list, srcFile) == false
   ]) : []
   include_list  = fileexists(format("%s/include.lst", local.source_prefix)) ? split(file(format("%s/include.lst", local.source_prefix)), "\n") : []
-  source_files  = fileset(path.module, format("%s/*.*", local.source_prefix))
+  source_files  = fileset(local.source_prefix, "*")
   source_prefix = format("%s/%s", var.source_code_root_path, var.function_name)
 }
 

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -17,7 +17,7 @@ locals {
 
 # Compress source code
 data "archive_file" "source" {
-  excludes    = local.excluded_files
+#  excludes    = local.excluded_files
   output_path = format("/tmp/%s/http_function_%s.zip", var.function_name, formatdate("YYMMDDhhmmss", timestamp()))
   source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
   type        = "zip"

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -6,17 +6,18 @@ like pulling data from external sources or doing (small) aggregations
 */
 
 locals {
-  excluded_files_list = length(local.include_list) > 0 ? toset([
+  excluded_files = length(local.include_list) > 0 ? toset([
     for srcFile in local.source_files :
     srcFile if contains(local.include_list, srcFile) == false
   ]) : []
-  include_list = fileexists(format("%s/include.lst", var.source_code_root_path)) ? split(file(format("%s/include.lst", var.source_code_root_path)), "\n") : []
-  source_files = fileset(path.module, format("%s/*.*", var.source_code_root_path))
+  include_list  = fileexists(format("%s/include.lst", local.source_prefix)) ? split(file(format("%s/include.lst", local.source_prefix)), "\n") : []
+  source_files  = fileset(path.module, format("%s/%s/*.*", local.source_prefix))
+  source_prefix = format("%s/%s", var.source_code_root_path, var.function_name)
 }
 
 # Compress source code
 data "archive_file" "source" {
-  excludes    = local.excluded_files_list
+  excludes    = local.excluded_files
   output_path = format("/tmp/%s/http_function_%s.zip", var.function_name, formatdate("YYMMDDhhmmss", timestamp()))
   source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
   type        = "zip"

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -10,8 +10,8 @@ locals {
     for srcFile in local.source_files :
     srcFile if contains(local.include_list, srcFile) == false
   ]) : []
-  include_list  = fileexists(format("%s/include.lst", local.source_prefix)) ? split(file(format("%s/include.lst", local.source_prefix)), "\n") : []
-  source_files  = fileset(local.source_prefix, "*")
+  include_list  = fileexists(format("%s/include.lst", local.source_prefix)) ? split("\n", file(format("%s/include.lst", local.source_prefix))) : []
+  source_files  = fileset(local.source_prefix, "**")
   source_prefix = format("%s/%s", var.source_code_root_path, var.function_name)
 }
 

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -9,7 +9,7 @@ like pulling data from external sources or doing (small) aggregations
 data "archive_file" "source" {
   type        = "zip"
   source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
-  output_path = format("/tmp/http_function_%s.zip", formatdate("YYMMDDhhmmss", timestamp()))
+  output_path = format("/tmp/%s/http_function_%s.zip", var.function_name, formatdate("YYMMDDhhmmss", timestamp()))
 }
 
 resource "google_storage_bucket_object" "functioncode" {

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -40,7 +40,7 @@ resource "google_cloudfunctions_function" "function" {
   region                        = var.project_region
   runtime                       = var.function_runtime
   service_account_email         = var.function_service_account_email
-  source_archive_bucket         = var.source_code_bucket_name
+  source_archive_bucket         = google_storage_bucket_object.functioncode.bucket
   source_archive_object         = google_storage_bucket_object.functioncode.name
   timeout                       = var.function_timeout
   trigger_http                  = true

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -5,24 +5,36 @@ Often used to do things that need to be executed at regular intervals,
 like pulling data from external sources or doing (small) aggregations
 */
 
+locals {
+  excluded_files_list = length(local.include_list) > 0 ? toset([
+    for srcFile in local.source_files :
+    srcFile if contains(local.include_list, srcFile) == false
+  ]) : []
+  include_list = fileexists(format("%s/include.lst", var.source_code_root_path)) ? split(file(format("%s/include.lst", var.source_code_root_path)), "\n") : []
+  source_files = fileset(path.module, format("%s/*.*", var.source_code_root_path))
+}
+
 # Compress source code
 data "archive_file" "source" {
-  type        = "zip"
-  source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
+  excludes    = local.excluded_files_list
   output_path = format("/tmp/%s/http_function_%s.zip", var.function_name, formatdate("YYMMDDhhmmss", timestamp()))
+  source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
+  type        = "zip"
 }
 
 resource "google_storage_bucket_object" "functioncode" {
-  name   = format("http_function_sources/%s/%s.zip", var.function_name, data.archive_file.source.output_md5)
+  name = format("http_function_sources/%s/%s.zip", var.function_name, data.archive_file.source.output_md5)
+
   bucket = var.source_code_bucket_name
   source = data.archive_file.source.output_path
 }
 
 resource "google_cloudfunctions_function" "function" {
+  name = format("%s%s", var.function_name, var.branch_suffix)
+
   available_memory_mb           = var.function_memory
   entry_point                   = var.function_entry_point
   environment_variables         = var.function_env_vars
-  name                          = format("%s%s", var.function_name, var.branch_suffix)
   project                       = var.project_id
   region                        = var.project_region
   runtime                       = var.function_runtime
@@ -64,10 +76,9 @@ resource "google_cloud_scheduler_job" "scheduler_job" {
 }
 
 resource "google_cloudfunctions_function_iam_member" "invoker" {
+  cloud_function = google_cloudfunctions_function.function.name
+  member         = "serviceAccount:${var.scheduler_service_account_email}"
   project        = google_cloudfunctions_function.function.project
   region         = google_cloudfunctions_function.function.region
-  cloud_function = google_cloudfunctions_function.function.name
-
-  role   = "roles/cloudfunctions.invoker"
-  member = "serviceAccount:${var.scheduler_service_account_email}"
+  role           = "roles/cloudfunctions.invoker"
 }

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -4,11 +4,27 @@ Cloud Function invoked by a scheduled job through a HTTP request
 Often used to do things that need to be executed at regular intervals,
 like pulling data from external sources or doing aggregations
 */
+locals {
+  timestamp = formatdate("YYMMDDhhmmss", timestamp())
+}
+
+# Compress source code
+data "archive_file" "source" {
+  type        = "zip"
+  source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
+  output_path = format("/tmp/http_function_%s.zip", local.timestamp)
+}
+
+resource "google_storage_bucket_object" "functioncode" {
+  name   = format("http_function_sources/%s/%s.zip", var.function_name, data.archive_file.source.output_md5)
+  bucket = var.source_code_bucket_name
+  source = data.archive_file.source.output_path
+}
+
 resource "google_cloudfunctions_function" "function" {
   available_memory_mb           = var.function_memory
   entry_point                   = var.function_entry_point
   environment_variables         = var.function_env_vars
-  labels                        = { last_deployed_at = formatdate("YYYYMMDDhhmmss", timestamp()) }
   name                          = format("%s%s", var.function_name, var.branch_suffix)
   project                       = var.project_id
   region                        = var.project_region
@@ -20,12 +36,6 @@ resource "google_cloudfunctions_function" "function" {
   trigger_http                  = true
   vpc_connector                 = var.function_vpc_connector
   vpc_connector_egress_settings = var.function_vpc_connector_egress_settings
-}
-
-resource "google_storage_bucket_object" "functioncode" {
-  name   = format("http_function_sources/%s/sourcecode%s.zip", var.function_name, var.branch_suffix)
-  bucket = var.source_code_bucket_name
-  source = "${var.source_code_root_path}/${var.function_name}/${var.function_name}.zip"
 }
 
 resource "google_cloud_scheduler_job" "scheduler_job" {

--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -2,17 +2,14 @@
 Cloud Function invoked by a scheduled job through a HTTP request
 
 Often used to do things that need to be executed at regular intervals,
-like pulling data from external sources or doing aggregations
+like pulling data from external sources or doing (small) aggregations
 */
-locals {
-  timestamp = formatdate("YYMMDDhhmmss", timestamp())
-}
 
 # Compress source code
 data "archive_file" "source" {
   type        = "zip"
   source_dir  = abspath(format("%s/%s", var.source_code_root_path, var.function_name))
-  output_path = format("/tmp/http_function_%s.zip", local.timestamp)
+  output_path = format("/tmp/http_function_%s.zip", formatdate("YYMMDDhhmmss", timestamp()))
 }
 
 resource "google_storage_bucket_object" "functioncode" {

--- a/terraform/cloud_function/scheduled/outputs.tf
+++ b/terraform/cloud_function/scheduled/outputs.tf
@@ -1,3 +1,11 @@
 output "https_trigger_url" {
   value = google_cloudfunctions_function.function.https_trigger_url
 }
+
+output "excluded_files" {
+  value = join(",", local.excluded_files)
+}
+
+output "include_list" {
+  value = join(",", local.include_list)
+}

--- a/terraform/cloud_function/scheduled/outputs.tf
+++ b/terraform/cloud_function/scheduled/outputs.tf
@@ -1,11 +1,3 @@
 output "https_trigger_url" {
   value = google_cloudfunctions_function.function.https_trigger_url
 }
-
-output "excluded_files" {
-  value = join(",", local.excluded_files)
-}
-
-output "include_list" {
-  value = join(",", local.include_list)
-}


### PR DESCRIPTION
~This time I got rid of locals as they may have caused TF to use the same value for all modules referencing it~

Turns out it was the output path that was not random enough (2 archive blocks created in same second would overwrite eachother)