### PR TITLE
add parameters for number of instances

### DIFF
--- a/terraform/cloud_function/scheduled/main.tf
+++ b/terraform/cloud_function/scheduled/main.tf
@@ -46,6 +46,8 @@ resource "google_cloudfunctions_function" "function" {
   trigger_http                  = true
   vpc_connector                 = var.function_vpc_connector
   vpc_connector_egress_settings = var.function_vpc_connector_egress_settings
+  max_instances                 = var.function_max_instances
+  min_instances                 = var.function_min_instances
 
   timeouts {
     create = "10m"

--- a/terraform/cloud_function/scheduled/variables.tf
+++ b/terraform/cloud_function/scheduled/variables.tf
@@ -14,6 +14,14 @@ variable "function_env_vars" {
   type    = map(any)
   default = {}
 }
+variable "function_min_instances" {
+  type    = number
+  default = 0
+}
+variable "function_max_instances" {
+  type    = number
+  default = 1000
+}
 variable "function_memory" {
   type    = number
   default = 128


### PR DESCRIPTION
Adds parameters to control the minimum and maximum number of CF instances that can run at the same time.