### PR TITLE
Added firestore to dependencies for use in dataproc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     install_requires=[
         "dask",
         "google-cloud-dataproc",
+        "google-cloud-firestore",
         "google-cloud-pubsub",
         "google-cloud-secret-manager",
         "google-cloud-storage",


### PR DESCRIPTION
this is a workaround to be able to use firestore in our dataproc jobs (eg https://github.com/Pararius/data-ingestors/pull/282)

hopefully fixes errors like https://console.cloud.google.com/dataproc/batches/europe-west1/casco-listing-rerun1d681dc4-90ad-4c86-87df-ba554e228122/monitoring?authuser=1&cloudshell=false&project=data-prod-123456

the better fix would be to use docker images for our dataproc jobs, where we could add all the dependencies we need (including platform-tools)