### PR TITLE
bug fix

### DIFF
--- a/treehouse/db.py
+++ b/treehouse/db.py
@@ -94,6 +94,10 @@ def query_to_parquet(
     db_connection: sqlalchemy.engine.Engine,
     skip_when_empty: bool = False,
 ) -> int:
+
+    # Due to a bug with SQLAlchemy and Pandas this fix is needed for now
+    query = sqlalchemy.text(query)
+
     df = pd.read_sql(
         query,
         con=db_connection,


### PR DESCRIPTION
### Why?
SQLAlchemy 2.0 removed functionality that Pandas still expects. So until Pandas is updated to address this, we need to implement a fix otherwise queries won't work.

### How?
Converting a query string to SQLAlchemy.text() object should fix the issue for now (according to the internet...).

### JIRA
*If there is a JIRA issue related to this change, add a link to it here*
