### PR TITLE
another fix

### DIFF
--- a/treehouse/db.py
+++ b/treehouse/db.py
@@ -95,12 +95,9 @@ def query_to_parquet(
     skip_when_empty: bool = False,
 ) -> int:
 
-    # Due to a bug with SQLAlchemy and Pandas this fix is needed for now
-    query = sqlalchemy.text(query)
-
-    df = pd.read_sql(
-        query,
-        con=db_connection,
+    df = pd.read_sql_query(
+        sql=sqlalchemy.text(query),
+        con=db_connection.connect(),
     )
 
     if skip_when_empty is True & df.shape[0] == 0:


### PR DESCRIPTION
### Why?
Previous fix didn't work, so here is another attempt. This one has been tested to work.

### How?
We need to start the connection to the database before passing the engine object to Pandas.

### JIRA
*If there is a JIRA issue related to this change, add a link to it here*
