### PR TITLE
update bigquery connector for spark

### DIFF
--- a/treehouse/processing.py
+++ b/treehouse/processing.py
@@ -29,7 +29,9 @@ def submit_dataproc_pyspark_batch(
     enable_bigquery: bool = False,
 ):
     if enable_bigquery:
-        jar_file_uris = ["gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar"]
+        jar_file_uris = [
+            "gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.13-0.28.0.jar"
+        ]
 
     if len(args) > 0:
         args = [base64.b64encode(arg.encode()) for arg in args]


### PR DESCRIPTION
### Why?
The version of Scala in the Dataproc serverless images has been updated to 2.13 which means the BigQuery connector we use no longer works.

### How?
Update the Spark BigQuery connector to a newer version that is compatible with Scala 2.13

### JIRA
*If there is a JIRA issue related to this change, add a link to it here*
