### PR TITLE
add custom encoder for JSON objects

### DIFF
--- a/treehouse/json.py
+++ b/treehouse/json.py
@@ -1,0 +1,15 @@
+from json import JSONEncoder
+from uuid import UUID
+from pandas import Timestamp
+
+
+class StamJSONEncoder(JSONEncoder):
+    def default(self, z):
+        if isinstance(z, Timestamp):
+            return z.strftime("%Y-%m-%d %H:%M:%S %Z")
+        elif isinstance(z, UUID):
+            return str(z)
+        elif isinstance(z, (int, float, bool)):
+            return str(z)
+        else:
+            return super().default(z)


### PR DESCRIPTION
### Why?
We want to be able to control how objects get serialised to JSON.

### How?
Write a custom encoder that implements our own conversions and defaults to the standard ones for the types we don't define.

### JIRA
*If there is a JIRA issue related to this change, add a link to it here*
