### PR TITLE
Added custom function to work around 'null issue' with greatest()

### DIFF
--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -1,0 +1,18 @@
+data "google_bigquery_dataset" "fn" {
+  dataset_id  = "fn"
+  description = "Collection of standard and custom routines used across the platform"
+  project     = local.google_project_id
+  location    = local.region
+}
+
+resource "google_bigquery_routine" "greatest_non_null" {
+  dataset_id      = data.google_bigquery_dataset.fn.dataset_id
+  routine_id      = "greatest_non_null"
+  routine_type    = "SCALAR_FUNCTION"
+  language        = "SQL"
+  definition_body = "(SELECT MAX(y) FROM UNNEST(x) AS y)"
+  arguments {
+    name          = "x"
+    argument_kind = "ANY_TYPE"
+  }
+}

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -1,16 +1,11 @@
-data "google_bigquery_dataset" "fn" {
-  dataset_id  = "fn"
-  description = "Collection of standard and custom routines used across the platform"
-  project     = local.google_project_id
-  location    = local.region
-}
-
 resource "google_bigquery_routine" "greatest_non_null" {
-  dataset_id      = data.google_bigquery_dataset.fn.dataset_id
+  dataset_id      = "fn" # manually created dataset so have to hardcode (there is no data block for datasets yet, see: https://github.com/hashicorp/terraform-provider-google/issues/5693)
+  definition_body = "(SELECT MAX(y) FROM UNNEST(x) AS y)"
+  language        = "SQL"
+  project         = local.google_project_id
   routine_id      = "greatest_non_null"
   routine_type    = "SCALAR_FUNCTION"
-  language        = "SQL"
-  definition_body = "(SELECT MAX(y) FROM UNNEST(x) AS y)"
+
   arguments {
     name          = "x"
     argument_kind = "ANY_TYPE"


### PR DESCRIPTION
### Why?
If you use the `GREATEST` function and one of its arguments is null, it will always return null. To workaround this (ignore the nulls) we created a custom function. Moving it to platform-tools makes it globally available.

### How?
Moved function from data-marts to here, with some terraform adjustments 

### JIRA
original ticket https://reclabs.atlassian.net/browse/DATA-890

