### PR TITLE
Added function for simpler 'emptyish' handling

### DIFF
--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -1,6 +1,6 @@
 resource "google_bigquery_routine" "empty_to_null" {
   dataset_id      = local.routines_dataset
-  definition_body = "NULLIF(NULLIF(x, 'None'), '')"
+  definition_body = "NULLIF(NULLIF(NULLIF(TRIM(x), 'null'), 'None'), '')"
   language        = "SQL"
   project         = local.google_project_id
   routine_id      = "empty_to_null${local.branch_suffix_underscore_edition}"
@@ -8,7 +8,8 @@ resource "google_bigquery_routine" "empty_to_null" {
 
   arguments {
     name          = "x"
-    argument_kind = "STRING"
+    data_type     = "STRING"
+    argument_kind = "FIXED_TYPE"
   }
 }
 
@@ -119,7 +120,9 @@ resource "google_bigquery_routine" "user_agent_parser" {
   routine_id         = "user_agent_parser${local.branch_suffix_underscore_edition}"
   routine_type       = "SCALAR_FUNCTION"
   language           = "JAVASCRIPT"
-  imported_libraries = [format("gs://%s/%s", google_storage_bucket_object.user_agent_parser_lib.bucket, google_storage_bucket_object.user_agent_parser_lib.name)]
+  imported_libraries = [
+    format("gs://%s/%s", google_storage_bucket_object.user_agent_parser_lib.bucket, google_storage_bucket_object.user_agent_parser_lib.name)
+  ]
   arguments {
     name      = "ua"
     data_type = "{\"typeKind\" :  \"STRING\"}"

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -1,6 +1,6 @@
 resource "google_bigquery_routine" "empty_to_null" {
   dataset_id      = local.routines_dataset
-  definition_body = "CASE WHEN LOWER(TRIM(x)) IN ('none', 'null', '') THEN NULL ELSE x"
+  definition_body = "CASE WHEN LOWER(TRIM(x)) IN ('none', 'null', '') THEN NULL ELSE x END AS y"
   language        = "SQL"
   project         = local.google_project_id
   routine_id      = "empty_to_null${local.branch_suffix_underscore_edition}"

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -1,6 +1,6 @@
 resource "google_bigquery_routine" "empty_to_null" {
   dataset_id      = local.routines_dataset
-  definition_body = "CASE WHEN LOWER(TRIM(x)) IN ('none', 'null', '') THEN NULL ELSE x END"
+  definition_body = "IF(LOWER(TRIM(x)) IN ('none', 'null', ''), NULL, x)"
   language        = "SQL"
   project         = local.google_project_id
   routine_id      = "empty_to_null${local.branch_suffix_underscore_edition}"

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -1,4 +1,16 @@
+resource "google_bigquery_routine" "empty_to_null" {
+  dataset_id      = local.routines_dataset
+  definition_body = "NULLIF(NULLIF(x, 'None'), '')"
+  language        = "SQL"
+  project         = local.google_project_id
+  routine_id      = "empty_to_null${local.branch_suffix_underscore_edition}"
+  routine_type    = "SCALAR_FUNCTION"
 
+  arguments {
+    name          = "x"
+    argument_kind = "STRING"
+  }
+}
 
 resource "google_bigquery_routine" "greatest_non_null" {
   dataset_id      = local.routines_dataset

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -8,7 +8,7 @@ resource "google_bigquery_routine" "empty_to_null" {
 
   arguments {
     name          = "x"
-    data_type     = jsonencode({"typeKind" = "STRING"})
+    data_type     = jsonencode({ "typeKind" = "STRING" })
     argument_kind = "FIXED_TYPE"
   }
 }
@@ -116,10 +116,10 @@ resource "google_storage_bucket_object" "user_agent_parser_lib" {
 }
 
 resource "google_bigquery_routine" "user_agent_parser" {
-  dataset_id         = local.routines_dataset
-  routine_id         = "user_agent_parser${local.branch_suffix_underscore_edition}"
-  routine_type       = "SCALAR_FUNCTION"
-  language           = "JAVASCRIPT"
+  dataset_id   = local.routines_dataset
+  routine_id   = "user_agent_parser${local.branch_suffix_underscore_edition}"
+  routine_type = "SCALAR_FUNCTION"
+  language     = "JAVASCRIPT"
   imported_libraries = [
     format("gs://%s/%s", google_storage_bucket_object.user_agent_parser_lib.bucket, google_storage_bucket_object.user_agent_parser_lib.name)
   ]

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -8,7 +8,7 @@ resource "google_bigquery_routine" "empty_to_null" {
 
   arguments {
     name          = "x"
-    data_type     = "STRING"
+    data_type     = jsonencode({"typeKind" = "STRING"})
     argument_kind = "FIXED_TYPE"
   }
 }

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -1,6 +1,6 @@
 resource "google_bigquery_routine" "empty_to_null" {
   dataset_id      = local.routines_dataset
-  definition_body = "CASE WHEN LOWER(TRIM(x)) IN ('none', 'null', '') THEN NULL ELSE x END AS y"
+  definition_body = "CASE WHEN LOWER(TRIM(x)) IN ('none', 'null', '') THEN NULL ELSE x END"
   language        = "SQL"
   project         = local.google_project_id
   routine_id      = "empty_to_null${local.branch_suffix_underscore_edition}"

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -1,6 +1,6 @@
 resource "google_bigquery_routine" "empty_to_null" {
   dataset_id      = local.routines_dataset
-  definition_body = "NULLIF(NULLIF(NULLIF(TRIM(x), 'null'), 'None'), '')"
+  definition_body = "CASE WHEN LOWER(TRIM(x)) IN ('none', 'null', '') THEN NULL ELSE x"
   language        = "SQL"
   project         = local.google_project_id
   routine_id      = "empty_to_null${local.branch_suffix_underscore_edition}"
@@ -8,7 +8,7 @@ resource "google_bigquery_routine" "empty_to_null" {
 
   arguments {
     name          = "x"
-    data_type     = jsonencode({ "typeKind" = "STRING" })
+    data_type     = jsonencode({ typeKind = "STRING" })
     argument_kind = "FIXED_TYPE"
   }
 }


### PR DESCRIPTION
### Why?
A lot of transformations need multiple NULLIF statements to make sure the data is either `null` or a real value. Woud be useful to have this globally available

### How?
Created function to handle almost all 'emptyish' cases

### JIRA
n/a
