### PR TITLE
Created routine to parse furnished types

### DIFF
--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -185,6 +185,10 @@ resource "google_bigquery_routine" "parse_furnished_types" {
     data_type     = "{\"typeKind\": \"ARRAY\", \"arrayElementType\": {\"typeKind\": \"STRING\"}}"
   }
   definition_body = <<EOF
+if (raw_types == null) {
+  return null;
+}
+
 final_types = [];
 raw_types = raw_types.map(raw_type => raw_type.toLowerCase());
 

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -115,10 +115,10 @@ resource "google_storage_bucket_object" "user_agent_parser_lib" {
 }
 
 resource "google_bigquery_routine" "user_agent_parser" {
-  dataset_id         = local.routines_dataset
-  routine_id         = "user_agent_parser${local.branch_suffix_underscore_edition}"
-  routine_type       = "SCALAR_FUNCTION"
-  language           = "JAVASCRIPT"
+  dataset_id   = local.routines_dataset
+  routine_id   = "user_agent_parser${local.branch_suffix_underscore_edition}"
+  routine_type = "SCALAR_FUNCTION"
+  language     = "JAVASCRIPT"
   imported_libraries = [
     format("gs://%s/%s", google_storage_bucket_object.user_agent_parser_lib.bucket, google_storage_bucket_object.user_agent_parser_lib.name)
   ]
@@ -187,13 +187,13 @@ resource "google_bigquery_routine" "greatest_furnished_type" {
 (
   SELECT
     IF(
-      REGEXP_CONTAINS(x, 'furnished|gemeubileerd'),
+      REGEXP_CONTAINS(y, 'furnished|gemeubileerd'),
       'furnished',
       IF(
-        REGEXP_CONTAINS(x, 'upholstered|gestoffeerd'),
+        REGEXP_CONTAINS(y, 'upholstered|gestoffeerd'),
         'upholstered',
         IF(
-          REGEXP_CONTAINS(x, 'shell|kaal'),
+          REGEXP_CONTAINS(y, 'shell|kaal'),
           'shell',
           NULL
         )

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -199,12 +199,16 @@ if (raw_types.filter(t => t.includes("furnished")) || raw_types.filter(t => t.in
   final_types.push("furnished");
 }
 
+if (final_types.length == 0) {
+  return null;
+}
+
 return final_types;
 EOF
 
   return_type = <<EOF
   {
-  	"typeKind": "ARRAY<STRING>"
+  	"typeKind": "ARRAY"
   }
 EOF
 }

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -184,23 +184,18 @@ resource "google_bigquery_routine" "greatest_furnished_type" {
     data_type     = "{\"typeKind\": \"ARRAY\", \"arrayElementType\": {\"typeKind\": \"STRING\"}}"
   }
   definition_body = <<EOF
-(
-  SELECT
+IF(
+  REGEXP_CONTAINS(ARRAY_TO_STRING(raw_types, ','), 'furnished|gemeubileerd'),
+  'furnished',
+  IF(
+    REGEXP_CONTAINS(ARRAY_TO_STRING(raw_types, ','), 'upholstered|gestoffeerd'),
+    'upholstered',
     IF(
-      REGEXP_CONTAINS(y, 'furnished|gemeubileerd'),
-      'furnished',
-      IF(
-        REGEXP_CONTAINS(y, 'upholstered|gestoffeerd'),
-        'upholstered',
-        IF(
-          REGEXP_CONTAINS(y, 'shell|kaal'),
-          'shell',
-          NULL
-        )
-      )
+      REGEXP_CONTAINS(ARRAY_TO_STRING(raw_types, ','), 'shell|kaal'),
+      'shell',
+      NULL
     )
-  FROM UNNEST(raw_types) AS y
-  LIMIT 1
+  )
 )
 EOF
   language        = "SQL"

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -182,7 +182,7 @@ resource "google_bigquery_routine" "furnished_type_parser" {
   arguments {
     name          = "raw_types"
     argument_kind = "FIXED_TYPE"
-    data_type     = "ARRAY<STRING>"
+    data_type     = "{\"typeKind\": \"ARRAY<STRING>\"}"
   }
   definition_body = <<EOF
 final_types = [];

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -192,15 +192,15 @@ if (raw_types == null || raw_types.length == 0) {
 final_types = [];
 raw_types = raw_types.map(raw_type => raw_type.toLowerCase());
 
-if (raw_types.filter(t => t.includes("shell")) || raw_types.filter(t => t.includes("kaal"))) {
+if (raw_types.filter(t => t.includes("shell") || t.includes("kaal"))) {
   final_types.push("shell");
 }
 
-if (raw_types.filter(t => t.includes("upholstered")) || raw_types.filter(t => t.includes("gestoffeerd"))) {
+if (raw_types.filter(t => t.includes("upholstered") || t.includes("gestoffeerd"))) {
   final_types.push("upholstered");
 }
 
-if (raw_types.filter(t => t.includes("furnished")) || raw_types.filter(t => t.includes("gemeubileerd"))) {
+if (raw_types.filter(t => t.includes("furnished") || t.includes("gemeubileerd"))) {
   final_types.push("furnished");
 }
 

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -115,10 +115,10 @@ resource "google_storage_bucket_object" "user_agent_parser_lib" {
 }
 
 resource "google_bigquery_routine" "user_agent_parser" {
-  dataset_id   = local.routines_dataset
-  routine_id   = "user_agent_parser${local.branch_suffix_underscore_edition}"
-  routine_type = "SCALAR_FUNCTION"
-  language     = "JAVASCRIPT"
+  dataset_id         = local.routines_dataset
+  routine_id         = "user_agent_parser${local.branch_suffix_underscore_edition}"
+  routine_type       = "SCALAR_FUNCTION"
+  language           = "JAVASCRIPT"
   imported_libraries = [
     format("gs://%s/%s", google_storage_bucket_object.user_agent_parser_lib.bucket, google_storage_bucket_object.user_agent_parser_lib.name)
   ]
@@ -176,12 +176,13 @@ EOF
 
 resource "google_bigquery_routine" "furnished_type_parser" {
   dataset_id   = local.routines_dataset
-  routine_id   = "furnished_type_parser${local.branch_suffix_underscore_edition}"
+  routine_id   = "parse_furnished_type${local.branch_suffix_underscore_edition}"
   routine_type = "SCALAR_FUNCTION"
   language     = "JAVASCRIPT"
   arguments {
     name          = "raw_types"
-    argument_kind = "ARRAY<STRING>"
+    argument_kind = "FIXED_TYPE"
+    data_type     = "ARRAY<STRING>"
   }
   definition_body = <<EOF
 final_types = [];

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -205,4 +205,6 @@ if (final_types.length == 0) {
 
 return final_types;
 EOF
+
+  return_type = "{\"typeKind\" :  \"ARRAY<STRING>\"}"
 }

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -205,10 +205,4 @@ if (final_types.length == 0) {
 
 return final_types;
 EOF
-
-  return_type = <<EOF
-  {
-  	"typeKind": "ARRAY"
-  }
-EOF
 }

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -181,7 +181,8 @@ resource "google_bigquery_routine" "parse_furnished_types" {
   language     = "JAVASCRIPT"
   arguments {
     name          = "raw_types"
-    argument_kind = "ANY_TYPE"
+    argument_kind = "FIXED_TYPE"
+    data_type     = "{\"typeKind\": \"ARRAY\", \"arrayElementType\": {\"typeKind\": \"STRING\"}}"
   }
   definition_body = <<EOF
 final_types = [];
@@ -206,5 +207,5 @@ if (final_types.length == 0) {
 return final_types;
 EOF
 
-  return_type = "{\"typeKind\" :  \"ARRAY<STRING>\"}"
+  return_type = "{\"typeKind\": \"ARRAY\", \"arrayElementType\": {\"typeKind\": \"STRING\"}}"
 }

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -174,15 +174,14 @@ resource "google_bigquery_routine" "user_agent_parser" {
 EOF
 }
 
-resource "google_bigquery_routine" "furnished_type_parser" {
+resource "google_bigquery_routine" "parse_furnished_types" {
   dataset_id   = local.routines_dataset
-  routine_id   = "parse_furnished_type${local.branch_suffix_underscore_edition}"
+  routine_id   = "parse_furnished_types${local.branch_suffix_underscore_edition}"
   routine_type = "SCALAR_FUNCTION"
   language     = "JAVASCRIPT"
   arguments {
     name          = "raw_types"
-    argument_kind = "FIXED_TYPE"
-    data_type     = "{\"typeKind\": \"ARRAY<STRING>\"}"
+    argument_kind = "ANY_TYPE"
   }
   definition_body = <<EOF
 final_types = [];

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -115,10 +115,10 @@ resource "google_storage_bucket_object" "user_agent_parser_lib" {
 }
 
 resource "google_bigquery_routine" "user_agent_parser" {
-  dataset_id         = local.routines_dataset
-  routine_id         = "user_agent_parser${local.branch_suffix_underscore_edition}"
-  routine_type       = "SCALAR_FUNCTION"
-  language           = "JAVASCRIPT"
+  dataset_id   = local.routines_dataset
+  routine_id   = "user_agent_parser${local.branch_suffix_underscore_edition}"
+  routine_type = "SCALAR_FUNCTION"
+  language     = "JAVASCRIPT"
   imported_libraries = [
     format("gs://%s/%s", google_storage_bucket_object.user_agent_parser_lib.bucket, google_storage_bucket_object.user_agent_parser_lib.name)
   ]

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -185,7 +185,7 @@ resource "google_bigquery_routine" "parse_furnished_types" {
     data_type     = "{\"typeKind\": \"ARRAY\", \"arrayElementType\": {\"typeKind\": \"STRING\"}}"
   }
   definition_body = <<EOF
-if (raw_types == null) {
+if (raw_types == null || raw_types.length == 0) {
   return null;
 }
 


### PR DESCRIPTION
### Why?
Now that we are moving to bigquery we also need to move this furnished type logic to it

### How?
Ported the python implementation to bigquery with a slight change in logic: ~I no longer implode the array back to an `or` separated string, instead I just return the normalized array itself. This should make analysis easier and less prone to ordering issues~ discussed with martijn and decided to take a more simpler approach that will fit current usecase better (single value, determined by high to low comparison)

### JIRA
n/a

test:
<img width="529" alt="Screenshot 2023-07-27 at 14 40 30" src="https://github.com/Pararius/platform-tools/assets/795661/bd33078a-e2f8-46fa-847b-703b312528fb">
