### PR TITLE
Make json_int handle floaty strings

### DIFF
--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -86,7 +86,7 @@ EOF
 
 resource "google_bigquery_routine" "json_get_int" {
   dataset_id      = local.routines_dataset
-  definition_body = "SAFE_CAST(JSON_VALUE(json_path) AS INT64)"
+  definition_body = "SAFE_CAST(SAFE_CAST(JSON_VALUE(json_path) AS NUMERIC) AS INT64)"
   language        = "SQL"
   project         = local.google_project_id
   routine_id      = "json_int${local.branch_suffix_underscore_edition}"


### PR DESCRIPTION
### Why?
Currently if a value like `"1.0"` is given, the result is `null`. We want this to be `1`

### How?
First cast the value to the `NUMERIC` superclass before casting it to an integer.

### JIRA
n/a

<img width="486" alt="Screenshot 2023-07-28 at 10 40 47" src="https://github.com/Pararius/platform-tools/assets/795661/446ce621-c2a4-412c-90ae-ce2662b0fc38">
