### PR TITLE
Added office hours to cronjob mapping

### DIFF
--- a/terraform/bigquery_scheduled_data_transfer/main.tf
+++ b/terraform/bigquery_scheduled_data_transfer/main.tf
@@ -4,7 +4,7 @@ locals {
     "daily" : "every day 00:00",
     "weekly" : "every monday 00:00",
     "quarterly" : "1 of jan,april,july,oct 00:00",
-    "office hours": "0 8-17 * * 1-5"
+    "office hours" : "0 8-17 * * 1-5"
   }
   bigquery_interval_mappings = {
     "hourly" : "1 HOUR",

--- a/terraform/bigquery_scheduled_data_transfer/main.tf
+++ b/terraform/bigquery_scheduled_data_transfer/main.tf
@@ -4,7 +4,7 @@ locals {
     "daily" : "every day 00:00",
     "weekly" : "every monday 00:00",
     "quarterly" : "1 of jan,april,july,oct 00:00",
-    "office hours" : "every hour between 06:00 and 15:00 on mon,tue,wed,thu,fri" # corrected for UTC (+2)
+    "office hours" : "every hour from 06:00 to 15:00 on mon,tue,wed,thu,fri" # corrected for UTC (+2)
   }
   bigquery_interval_mappings = {
     "hourly" : "1 HOUR",

--- a/terraform/bigquery_scheduled_data_transfer/main.tf
+++ b/terraform/bigquery_scheduled_data_transfer/main.tf
@@ -4,7 +4,7 @@ locals {
     "daily" : "every day 00:00",
     "weekly" : "every monday 00:00",
     "quarterly" : "1 of jan,april,july,oct 00:00",
-    "office hours" : "every 1 hours from 06:00 to 15:00 on mon,tue,wed,thu,fri" # corrected for UTC (+2)
+    "office hours" : "every hour from 06:00 to 15:00" # corrected for UTC (+2)
   }
   bigquery_interval_mappings = {
     "hourly" : "1 HOUR",

--- a/terraform/bigquery_scheduled_data_transfer/main.tf
+++ b/terraform/bigquery_scheduled_data_transfer/main.tf
@@ -4,7 +4,7 @@ locals {
     "daily" : "every day 00:00",
     "weekly" : "every monday 00:00",
     "quarterly" : "1 of jan,april,july,oct 00:00",
-    "office hours" : "every mon,tue,wed,thu,fri 06:00-15:00" # corrected for UTC (+2)
+    "office hours" : "every hour between 06:00 and 15:00 on mon,tue,wed,thu,fri" # corrected for UTC (+2)
   }
   bigquery_interval_mappings = {
     "hourly" : "1 HOUR",

--- a/terraform/bigquery_scheduled_data_transfer/main.tf
+++ b/terraform/bigquery_scheduled_data_transfer/main.tf
@@ -4,7 +4,7 @@ locals {
     "daily" : "every day 00:00",
     "weekly" : "every monday 00:00",
     "quarterly" : "1 of jan,april,july,oct 00:00",
-    "office hours" : "every hour from 06:00 to 15:00" # corrected for UTC (+2)
+    "office hours" : "every hour from 06:00 to 16:00" # corrected for UTC (+2)
   }
   bigquery_interval_mappings = {
     "hourly" : "1 HOUR",

--- a/terraform/bigquery_scheduled_data_transfer/main.tf
+++ b/terraform/bigquery_scheduled_data_transfer/main.tf
@@ -3,7 +3,8 @@ locals {
     "hourly" : "every hour",
     "daily" : "every day 00:00",
     "weekly" : "every monday 00:00",
-    "quarterly" : "1 of jan,april,july,oct 00:00"
+    "quarterly" : "1 of jan,april,july,oct 00:00",
+    "office hours": "0 8-17 * * 1-5"
   }
   bigquery_interval_mappings = {
     "hourly" : "1 HOUR",

--- a/terraform/bigquery_scheduled_data_transfer/main.tf
+++ b/terraform/bigquery_scheduled_data_transfer/main.tf
@@ -4,7 +4,7 @@ locals {
     "daily" : "every day 00:00",
     "weekly" : "every monday 00:00",
     "quarterly" : "1 of jan,april,july,oct 00:00",
-    "office hours" : "0 8-17 * * 1-5"
+    "office hours" : "every mon,tue,wed,thu,fri 06:00-15:00" # corrected for UTC (+2)
   }
   bigquery_interval_mappings = {
     "hourly" : "1 HOUR",

--- a/terraform/bigquery_scheduled_data_transfer/main.tf
+++ b/terraform/bigquery_scheduled_data_transfer/main.tf
@@ -4,7 +4,8 @@ locals {
     "daily" : "every day 00:00",
     "weekly" : "every monday 00:00",
     "quarterly" : "1 of jan,april,july,oct 00:00",
-    "office hours" : "every hour from 06:00 to 16:00" # corrected for UTC (+2)
+    # corrected for UTC -> Europe/Amsterdam including DST (+1 or +2), unfortunately the format does not seem to support combining hour ranges with day ranges
+    "office hours" : "every hour from 06:00 to 16:00"
   }
   bigquery_interval_mappings = {
     "hourly" : "1 HOUR",

--- a/terraform/bigquery_scheduled_data_transfer/main.tf
+++ b/terraform/bigquery_scheduled_data_transfer/main.tf
@@ -4,7 +4,7 @@ locals {
     "daily" : "every day 00:00",
     "weekly" : "every monday 00:00",
     "quarterly" : "1 of jan,april,july,oct 00:00",
-    "office hours" : "every hour from 06:00 to 15:00 on mon,tue,wed,thu,fri" # corrected for UTC (+2)
+    "office hours" : "every mon,tue,wed,thu,fri from 06:00 to 15:00" # corrected for UTC (+2)
   }
   bigquery_interval_mappings = {
     "hourly" : "1 HOUR",

--- a/terraform/bigquery_scheduled_data_transfer/main.tf
+++ b/terraform/bigquery_scheduled_data_transfer/main.tf
@@ -4,7 +4,7 @@ locals {
     "daily" : "every day 00:00",
     "weekly" : "every monday 00:00",
     "quarterly" : "1 of jan,april,july,oct 00:00",
-    "office hours" : "every mon,tue,wed,thu,fri from 06:00 to 15:00" # corrected for UTC (+2)
+    "office hours" : "every 1 hours from 06:00 to 15:00 on mon,tue,wed,thu,fri" # corrected for UTC (+2)
   }
   bigquery_interval_mappings = {
     "hourly" : "1 HOUR",


### PR DESCRIPTION
### Why?
In order for us to schedule jobs during office hours, its nice to have a mapping defined for it so we don't have to repeat (complex) cron formats.

### How?
Added mapping for office hours

### JIRA
https://reclabs.atlassian.net/browse/DATA-970
and 
https://github.com/Pararius/stam/pull/125 for the implementation
