### PR TITLE
Added boilerplate and initial script for checking google docs access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,5 @@ run: ## Runs a cloud function from a given context, the second argument can be u
 	@[ -n "$(CONTEXT)" ] || { echo 'You must supply a path to the function (context) in the form of `make run CONTEXT=./src/your-function`'; exit 1; }
 	CONTEXT=$(CONTEXT) docker compose run --rm cloud-function python -c "import main; main.handler($(ARGS));"
 
-test: build ## Runs all tests for this library
+test: ## Runs all tests for this library
 	docker-compose run --rm python pytest $(ARGS)

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,17 @@ help: ## Show this help message.
 	@echo 'targets:'
 	@egrep '^(.+)\:(.+)?\ ##\ (.+)' ${MAKEFILE_LIST} | column -t -c 2 -s ':#'
 
-cs: build ## Checks for code style issues
-	docker-compose run --rm python black --check .
+cs: ## Checks for code style issues
+	docker compose run --rm cs black --check .
 	terraform -chdir=terraform fmt -check -recursive .
 
-cs-fix: build ## Fixes code style issues
-	docker-compose run --rm python black .
+cs-fix: ## Fixes code style issues
+	docker compose run --rm cs black .
 	terraform -chdir=terraform fmt -recursive .
 
-build: ## Builds the image including the setup.py file (run this when you've changed dependencies)
-	docker-compose build python
+run: ## Runs a cloud function from a given context, the second argument can be used to pass the request/event
+	@[ -n "$(CONTEXT)" ] || { echo 'You must supply a path to the function (context) in the form of `make run CONTEXT=./src/your-function`'; exit 1; }
+	CONTEXT=$(CONTEXT) docker compose run --rm cloud-function python -c "import main; main.handler($(ARGS));"
 
 test: build ## Runs all tests for this library
 	docker-compose run --rm python pytest $(ARGS)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,22 @@
 version: "3"
 
 services:
-  python:
-    build: .
+  cloud-function:
+    build:
+      dockerfile: ${PWD}/docker/cloud-function/Dockerfile
+      context: ${CONTEXT:-.}
+    volumes:
+      - ${CONTEXT:-.}:/app
+      - ~/.config/gcloud:/tmp/.config/gcloud
+    working_dir: /app
+    environment:
+      CLOUDSDK_CONFIG: /tmp/.config/gcloud
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/.config/gcloud/application_default_credentials.json
+
+  cs:
+    build:
+      dockerfile: ./docker/cs/Dockerfile
+      context: .
     volumes:
       - ./:/app
     working_dir: /app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,3 +20,9 @@ services:
     volumes:
       - ./:/app
     working_dir: /app
+
+  python:
+    build: .
+    volumes:
+      - ./:/app
+    working_dir: /app

--- a/docker/cloud-function/Dockerfile
+++ b/docker/cloud-function/Dockerfile
@@ -1,0 +1,22 @@
+# NOTE: this image is never used in production (relies on Google's runtime), it only serves to mimick production as much as possible for development purposes.
+FROM python:3.10.4-slim-buster
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        git \
+        libssl-dev \
+        make \
+        default-libmysqlclient-dev \
+;
+
+COPY requirements.txt ./
+
+ENV PYTHONPATH "$PYTHONPATH:$PWD"
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install -U \
+        pytest \
+        pytest-mock \
+;

--- a/docker/cs/Dockerfile
+++ b/docker/cs/Dockerfile
@@ -1,0 +1,6 @@
+# NOTE: this image is never used in production (relies on Google's runtime), it only serves to mimick production as much as possible for development purposes.
+FROM python:3.10.4-slim-buster
+
+RUN pip install -U \
+        black \
+;

--- a/terraform/cloud_function/archive_file_prefixed/README.md
+++ b/terraform/cloud_function/archive_file_prefixed/README.md
@@ -1,0 +1,39 @@
+# archive-file-prefixed
+
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [archive_file.source](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | A unique identity for this archived file | `string` | n/a | yes |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | The path to the directory containing all the files you want to archive. Nested directories are kept intact. | `string` | n/a | yes |
+| <a name="input_type"></a> [type](#input\_type) | The type of archive file to produce | `string` | `"zip"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_output_md5"></a> [output\_md5](#output\_output\_md5) | n/a |
+| <a name="output_output_path"></a> [output\_path](#output\_output\_path) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/cloud_function/archive_file_prefixed/main.tf
+++ b/terraform/cloud_function/archive_file_prefixed/main.tf
@@ -1,0 +1,15 @@
+locals {
+  excluded_files = length(local.include_list) > 0 ? toset([
+    for srcFile in local.source_files :
+    srcFile if contains(local.include_list, srcFile) == false
+  ]) : []
+  include_list = fileexists(format("%s/include.lst", var.prefix)) ? split("\n", file(format("%s/include.lst", var.prefix))) : []
+  source_files = fileset(var.prefix, "**")
+}
+
+data "archive_file" "source" {
+  excludes    = local.excluded_files
+  output_path = format("/tmp/%s/archive.%s", var.name, var.type)
+  source_dir  = abspath(var.prefix)
+  type        = "zip"
+}

--- a/terraform/cloud_function/archive_file_prefixed/outputs.tf
+++ b/terraform/cloud_function/archive_file_prefixed/outputs.tf
@@ -1,0 +1,7 @@
+output "output_path" {
+  value = data.archive_file.source.output_path
+}
+
+output "output_md5" {
+  value = data.archive_file.source.output_md5
+}

--- a/terraform/cloud_function/archive_file_prefixed/variables.tf
+++ b/terraform/cloud_function/archive_file_prefixed/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type        = string
+  description = "A unique identity for this archived file"
+}
+
+variable "type" {
+  type        = string
+  default     = "zip"
+  description = "The type of archive file to produce"
+}
+
+variable "prefix" {
+  type        = string
+  description = "The path to the directory containing all the files you want to archive. Nested directories are kept intact."
+}

--- a/terraform/cloud_function/archive_file_selective/README.md
+++ b/terraform/cloud_function/archive_file_selective/README.md
@@ -1,0 +1,36 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [archive_file.source](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_files"></a> [files](#input\_files) | A list of (relative or absolute) paths to the files you want to include in the archive. | `list(string)` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | A unique identity for this archived file | `string` | n/a | yes |
+| <a name="input_type"></a> [type](#input\_type) | The type of archive file to produce | `string` | `"zip"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_output_md5"></a> [output\_md5](#output\_output\_md5) | n/a |
+| <a name="output_output_path"></a> [output\_path](#output\_output\_path) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/cloud_function/archive_file_selective/main.tf
+++ b/terraform/cloud_function/archive_file_selective/main.tf
@@ -1,0 +1,12 @@
+data "archive_file" "source" {
+  type        = var.type
+  output_path = format("/tmp/%s/archive.%s", var.name, var.type)
+
+  dynamic "source" {
+    for_each = var.files
+    content {
+      content  = file(abspath(source.value))
+      filename = basename(source.value)
+    }
+  }
+}

--- a/terraform/cloud_function/archive_file_selective/outputs.tf
+++ b/terraform/cloud_function/archive_file_selective/outputs.tf
@@ -1,0 +1,7 @@
+output "output_path" {
+  value = data.archive_file.source.output_path
+}
+
+output "output_md5" {
+  value = data.archive_file.source.output_md5
+}

--- a/terraform/cloud_function/archive_file_selective/variables.tf
+++ b/terraform/cloud_function/archive_file_selective/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type        = string
+  description = "A unique identity for this archived file"
+}
+
+variable "type" {
+  type        = string
+  default     = "zip"
+  description = "The type of archive file to produce"
+}
+
+variable "files" {
+  type        = list(string)
+  description = "A list of (relative or absolute) paths to the files you want to include in the archive."
+}

--- a/terraform/cloud_function/cloud_function/README.md
+++ b/terraform/cloud_function/cloud_function/README.md
@@ -1,0 +1,60 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_archive_prefixed"></a> [archive\_prefixed](#module\_archive\_prefixed) | ./../archive_file_prefixed | n/a |
+| <a name="module_archive_selective"></a> [archive\_selective](#module\_archive\_selective) | ./../archive_file_selective | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_cloud_scheduler_job.scheduler_job](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_scheduler_job) | resource |
+| [google_cloudfunctions_function.http_function](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions_function) | resource |
+| [google_cloudfunctions_function.pubsub_function](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions_function) | resource |
+| [google_storage_bucket_object.function_source_code](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_function_entry_point"></a> [function\_entry\_point](#input\_function\_entry\_point) | The name of the function that is called in your source code when the Cloud Function is triggered. | `string` | `"handler"` | no |
+| <a name="input_function_env_vars"></a> [function\_env\_vars](#input\_function\_env\_vars) | Environment variables that are passed to the Cloud Function and can be used to provide additional configuration. | `map(any)` | `{}` | no |
+| <a name="input_function_max_instances"></a> [function\_max\_instances](#input\_function\_max\_instances) | The maximum number of Cloud Function instances that should be running at any time. | `number` | `1000` | no |
+| <a name="input_function_memory"></a> [function\_memory](#input\_function\_memory) | The amount of memory (in megabytes) that the Cloud Function instance is allowed to consume. | `number` | `128` | no |
+| <a name="input_function_min_instances"></a> [function\_min\_instances](#input\_function\_min\_instances) | The minimum number of Cloud Function instances that should be running at any time. | `number` | `0` | no |
+| <a name="input_function_name"></a> [function\_name](#input\_function\_name) | A unique identity for this function, must be different than other functions you have in your project AND terraform workspaces (should include suffix!). | `string` | n/a | yes |
+| <a name="input_function_retry_on_failure"></a> [function\_retry\_on\_failure](#input\_function\_retry\_on\_failure) | Indicates whether the function should be retried on failure. Only applies when you expect your code to fail now and then. | `bool` | `false` | no |
+| <a name="input_function_runtime"></a> [function\_runtime](#input\_function\_runtime) | The runtime used to execute your code, see https://cloud.google.com/functions/docs/runtime-support for more options. | `string` | `"python310"` | no |
+| <a name="input_function_service_account_email"></a> [function\_service\_account\_email](#input\_function\_service\_account\_email) | The email address of the service account used to run the Cloud Function instance. You should male sure it has all the roles necessary to run your code. | `string` | n/a | yes |
+| <a name="input_function_timeout"></a> [function\_timeout](#input\_function\_timeout) | The maximum time in seconds to allow for this function to run. Can not be more than 540. | `number` | `60` | no |
+| <a name="input_function_type"></a> [function\_type](#input\_function\_type) | The type of Cloud Function used. Controls how the function is triggered. Can be either 'http' or 'pubsub' | `string` | `"http"` | no |
+| <a name="input_function_vpc_connector"></a> [function\_vpc\_connector](#input\_function\_vpc\_connector) | When provided, this allows the function to connect to the outside world through a specific VPC. Useful for connecting with systems that have an IP whitelist. | `string` | `null` | no |
+| <a name="input_function_vpc_connector_egress_settings"></a> [function\_vpc\_connector\_egress\_settings](#input\_function\_vpc\_connector\_egress\_settings) | Restricts the kind of traffic allowed to pass through the VPC connector. Allowed values are ALL\_TRAFFIC and PRIVATE\_RANGES\_ONLY. Defaults to PRIVATE\_RANGES\_ONLY. If unset, this field preserves the previously set value. | `string` | `null` | no |
+| <a name="input_google_cloud_project_id"></a> [google\_cloud\_project\_id](#input\_google\_cloud\_project\_id) | The ID of the Google Cloud Project used to deploy this function. | `string` | n/a | yes |
+| <a name="input_google_cloud_region"></a> [google\_cloud\_region](#input\_google\_cloud\_region) | The region used to deploy this function on Google Cloud. | `string` | n/a | yes |
+| <a name="input_pubsub_topic_id"></a> [pubsub\_topic\_id](#input\_pubsub\_topic\_id) | The ID of the pubsub topic that this function should be triggered by (if any). Only works in conjunction with `type=pubsub`. | `string` | `null` | no |
+| <a name="input_scheduler_service_account_email"></a> [scheduler\_service\_account\_email](#input\_scheduler\_service\_account\_email) | The email address of the service account used to schedule the Cloud Function instance (if configured to do so). You should make sure it has at least the `roles/cloudfunctions.invoker` role for it to work. | `string` | `null` | no |
+| <a name="input_schedulers"></a> [schedulers](#input\_schedulers) | Specifies one or more intervals at which your Cloud Function should be triggered, and the request it should receive. | <pre>list(object({<br>    attempt_deadline = optional(string)<br>    name             = string<br>    schedule         = string<br>    request_body     = optional(string)<br>    request_method   = optional(string)<br>    retry_count      = optional(number)<br>  }))</pre> | `[]` | no |
+| <a name="input_source_code_bucket_name"></a> [source\_code\_bucket\_name](#input\_source\_code\_bucket\_name) | The name of the bucket where source code for this function is stored. | `string` | n/a | yes |
+| <a name="input_source_files"></a> [source\_files](#input\_source\_files) | Points to specific files that make up your function. It can only point to a single `main.py` but more files can be added to extend functionality. Conflicts with `source_prefix`. | `list(string)` | `[]` | no |
+| <a name="input_source_prefix"></a> [source\_prefix](#input\_source\_prefix) | Points to the directory containing your function code. It should have at least a `main.py` file and an optional `requirements.txt` to install dependencies. Conflicts with `source_files`. | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_https_trigger_url"></a> [https\_trigger\_url](#output\_https\_trigger\_url) | n/a |
+| <a name="output_name"></a> [name](#output\_name) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/cloud_function/cloud_function/main.tf
+++ b/terraform/cloud_function/cloud_function/main.tf
@@ -1,0 +1,107 @@
+module "archive_selective" {
+  count  = length(var.source_files) > 0 ? 1 : 0
+  source = "./../archive_file_selective"
+  files  = var.source_files
+  name   = var.function_name
+}
+
+module "archive_prefixed" {
+  count  = length(var.source_files) == 0 ? 1 : 0
+  source = "./../archive_file_prefixed"
+  prefix = var.source_prefix
+  name   = var.function_name
+}
+
+resource "google_storage_bucket_object" "function_source_code" {
+  name = format("function_source_code/%s/%s.zip", var.function_name, length(var.source_files) > 0 ? module.archive_selective[0].output_md5 : module.archive_prefixed[0].output_md5)
+
+  bucket = var.source_code_bucket_name
+  source = length(var.source_files) > 0 ? module.archive_selective[0].output_path : module.archive_prefixed[0].output_path
+}
+
+resource "google_cloudfunctions_function" "http_function" {
+  count                         = var.function_type == "http" ? 1 : 0
+  name                          = var.function_name
+  available_memory_mb           = var.function_memory
+  entry_point                   = var.function_entry_point
+  environment_variables         = var.function_env_vars
+  project                       = var.google_cloud_project_id
+  region                        = var.google_cloud_region
+  runtime                       = var.function_runtime
+  service_account_email         = var.function_service_account_email
+  source_archive_bucket         = google_storage_bucket_object.function_source_code.bucket
+  source_archive_object         = google_storage_bucket_object.function_source_code.name
+  timeout                       = var.function_timeout
+  trigger_http                  = true
+  vpc_connector                 = var.function_vpc_connector
+  vpc_connector_egress_settings = var.function_vpc_connector_egress_settings
+  max_instances                 = var.function_max_instances
+  min_instances                 = var.function_min_instances
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+  }
+}
+
+resource "google_cloudfunctions_function" "pubsub_function" {
+  count                         = var.function_type == "pubsub" ? 1 : 0
+  name                          = var.function_name
+  available_memory_mb           = var.function_memory
+  entry_point                   = var.function_entry_point
+  environment_variables         = var.function_env_vars
+  project                       = var.google_cloud_project_id
+  region                        = var.google_cloud_region
+  runtime                       = var.function_runtime
+  service_account_email         = var.function_service_account_email
+  source_archive_bucket         = google_storage_bucket_object.function_source_code.bucket
+  source_archive_object         = google_storage_bucket_object.function_source_code.name
+  timeout                       = var.function_timeout
+  vpc_connector                 = var.function_vpc_connector
+  vpc_connector_egress_settings = var.function_vpc_connector_egress_settings
+  max_instances                 = var.function_max_instances
+  min_instances                 = var.function_min_instances
+
+  timeouts {
+    create = "10m"
+    update = "10m"
+  }
+
+  event_trigger {
+    event_type = "google.pubsub.topic.publish"
+    resource   = var.pubsub_topic_id
+    failure_policy {
+      retry = var.function_retry_on_failure
+    }
+  }
+}
+
+resource "google_cloud_scheduler_job" "scheduler_job" {
+  for_each = { for scheduler in var.schedulers : scheduler.name => scheduler if var.function_type == "http" }
+
+  attempt_deadline = each.value.attempt_deadline != null ? each.value.attempt_deadline : "320s"
+  name             = each.value.name
+  schedule         = each.value.schedule
+  time_zone        = "UTC"
+  project          = var.google_cloud_project_id
+  region           = var.google_cloud_region
+
+  retry_config {
+    retry_count = each.value.retry_count != null ? each.value.retry_count : 1
+  }
+
+  http_target {
+    body        = base64encode(each.value.request_body != null ? each.value.request_body : "{}")
+    http_method = each.value.request_method != null ? each.value.request_method : "POST"
+
+    headers = {
+      "Content-Type" : "application/json"
+    }
+
+    uri = google_cloudfunctions_function.http_function[0].https_trigger_url
+
+    oidc_token {
+      service_account_email = var.scheduler_service_account_email
+    }
+  }
+}

--- a/terraform/cloud_function/cloud_function/outputs.tf
+++ b/terraform/cloud_function/cloud_function/outputs.tf
@@ -1,0 +1,7 @@
+output "https_trigger_url" {
+  value = var.function_type == "http" ? google_cloudfunctions_function.http_function[0].https_trigger_url : null
+}
+
+output "name" {
+  value = var.function_type == "http" ? google_cloudfunctions_function.http_function[0].name : google_cloudfunctions_function.pubsub_function[0].name
+}

--- a/terraform/cloud_function/cloud_function/variables.tf
+++ b/terraform/cloud_function/cloud_function/variables.tf
@@ -1,0 +1,107 @@
+variable "function_entry_point" {
+  type        = string
+  default     = "handler"
+  description = "The name of the function that is called in your source code when the Cloud Function is triggered."
+}
+variable "function_env_vars" {
+  type        = map(any)
+  default     = {}
+  description = "Environment variables that are passed to the Cloud Function and can be used to provide additional configuration."
+}
+variable "function_type" {
+  type        = string
+  default     = "http"
+  description = "The type of Cloud Function used. Controls how the function is triggered. Can be either 'http' or 'pubsub'"
+}
+variable "function_min_instances" {
+  type        = number
+  default     = 0
+  description = "The minimum number of Cloud Function instances that should be running at any time."
+}
+variable "function_max_instances" {
+  type        = number
+  default     = 1000
+  description = "The maximum number of Cloud Function instances that should be running at any time."
+}
+variable "function_memory" {
+  type        = number
+  default     = 128
+  description = "The amount of memory (in megabytes) that the Cloud Function instance is allowed to consume."
+}
+variable "function_name" {
+  type        = string
+  description = "A unique identity for this function, must be different than other functions you have in your project AND terraform workspaces (should include suffix!)."
+}
+variable "function_retry_on_failure" {
+  type        = bool
+  default     = false
+  description = "Indicates whether the function should be retried on failure. Only applies when you expect your code to fail now and then."
+}
+variable "function_runtime" {
+  type        = string
+  default     = "python310"
+  description = "The runtime used to execute your code, see https://cloud.google.com/functions/docs/runtime-support for more options."
+}
+variable "function_service_account_email" {
+  type        = string
+  description = "The email address of the service account used to run the Cloud Function instance. You should male sure it has all the roles necessary to run your code."
+}
+variable "function_timeout" {
+  type        = number
+  default     = 60
+  description = "The maximum time in seconds to allow for this function to run. Can not be more than 540."
+}
+variable "function_vpc_connector" {
+  type        = string
+  default     = null
+  description = "When provided, this allows the function to connect to the outside world through a specific VPC. Useful for connecting with systems that have an IP whitelist."
+}
+variable "function_vpc_connector_egress_settings" {
+  type        = string
+  default     = null
+  description = "Restricts the kind of traffic allowed to pass through the VPC connector. Allowed values are ALL_TRAFFIC and PRIVATE_RANGES_ONLY. Defaults to PRIVATE_RANGES_ONLY. If unset, this field preserves the previously set value."
+}
+variable "google_cloud_project_id" {
+  type        = string
+  description = "The ID of the Google Cloud Project used to deploy this function."
+}
+variable "google_cloud_region" {
+  type        = string
+  description = "The region used to deploy this function on Google Cloud."
+}
+variable "scheduler_service_account_email" {
+  type        = string
+  default     = null
+  description = "The email address of the service account used to schedule the Cloud Function instance (if configured to do so). You should make sure it has at least the `roles/cloudfunctions.invoker` role for it to work."
+}
+variable "schedulers" {
+  default = []
+  type = list(object({
+    attempt_deadline = optional(string)
+    name             = string
+    schedule         = string
+    request_body     = optional(string)
+    request_method   = optional(string)
+    retry_count      = optional(number)
+  }))
+  description = "Specifies one or more intervals at which your Cloud Function should be triggered, and the request it should receive."
+}
+variable "source_code_bucket_name" {
+  type        = string
+  description = "The name of the bucket where source code for this function is stored."
+}
+variable "source_prefix" {
+  type        = string
+  default     = null
+  description = "Points to the directory containing your function code. It should have at least a `main.py` file and an optional `requirements.txt` to install dependencies. Conflicts with `source_files`."
+}
+variable "source_files" {
+  type        = list(string)
+  default     = []
+  description = "Points to specific files that make up your function. It can only point to a single `main.py` but more files can be added to extend functionality. Conflicts with `source_prefix`."
+}
+variable "pubsub_topic_id" {
+  type        = string
+  default     = null
+  description = "The ID of the pubsub topic that this function should be triggered by (if any). Only works in conjunction with `type=pubsub`."
+}

--- a/terraform/cloud_function/pubsub_custom_loader/README.md
+++ b/terraform/cloud_function/pubsub_custom_loader/README.md
@@ -1,0 +1,41 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_custom_loader"></a> [custom\_loader](#module\_custom\_loader) | ./../cloud_function | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_pubsub_subscription.custom_extractor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_custom_environment_variables"></a> [custom\_environment\_variables](#input\_custom\_environment\_variables) | Variables that you would like to have available to your custom loader | `map(string)` | `{}` | no |
+| <a name="input_custom_source_code"></a> [custom\_source\_code](#input\_custom\_source\_code) | Path to the directory that will be used as source code for the loading stage. | `string` | n/a | yes |
+| <a name="input_google_cloud_project_id"></a> [google\_cloud\_project\_id](#input\_google\_cloud\_project\_id) | The ID of the Google Cloud Project used to deploy this function. | `string` | n/a | yes |
+| <a name="input_google_cloud_region"></a> [google\_cloud\_region](#input\_google\_cloud\_region) | The region used to deploy this function on Google Cloud. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name used to identify this collection of resources, automatically gets suffixed with `suffix` variable. | `string` | n/a | yes |
+| <a name="input_pubsub_topic_id"></a> [pubsub\_topic\_id](#input\_pubsub\_topic\_id) | The full PubSub topic ID that this loader should subscribe to (should start with projects/[project-id]/...). | `string` | n/a | yes |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The Service Account used to run (and optionally, schedule) the cloud functions needed for each step. | `string` | n/a | yes |
+| <a name="input_source_code_bucket_name"></a> [source\_code\_bucket\_name](#input\_source\_code\_bucket\_name) | The bucket used to store the source code needed to run a step. | `string` | n/a | yes |
+| <a name="input_suffix"></a> [suffix](#input\_suffix) | The suffix added to all resource names in order to differentiate environments (e.g. a feature branch or production) on Google Cloud. | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/terraform/cloud_function/pubsub_custom_loader/main.tf
+++ b/terraform/cloud_function/pubsub_custom_loader/main.tf
@@ -1,0 +1,34 @@
+resource "google_pubsub_subscription" "custom_extractor" {
+  name    = format("%s_custom_extractor%s", var.name, var.suffix)
+  topic   = var.pubsub_topic_id
+  project = var.google_cloud_project_id
+
+  ack_deadline_seconds         = 150
+  enable_exactly_once_delivery = false
+
+  push_config {
+    push_endpoint = module.custom_loader.https_trigger_url
+    oidc_token {
+      service_account_email = var.service_account_email
+    }
+  }
+
+  retry_policy {
+    minimum_backoff = "30s"
+    maximum_backoff = "600s"
+  }
+}
+
+module "custom_loader" {
+  function_env_vars              = var.custom_environment_variables
+  function_memory                = 512
+  function_name                  = format("%s_custom_loader%s", var.name, var.suffix)
+  function_service_account_email = var.service_account_email
+  function_timeout               = 300
+  function_type                  = "http"
+  google_cloud_project_id        = var.google_cloud_project_id
+  google_cloud_region            = var.google_cloud_region
+  source                         = "./../cloud_function"
+  source_code_bucket_name        = var.source_code_bucket_name
+  source_prefix                  = var.custom_source_code
+}

--- a/terraform/cloud_function/pubsub_custom_loader/variables.tf
+++ b/terraform/cloud_function/pubsub_custom_loader/variables.tf
@@ -1,0 +1,45 @@
+variable "name" {
+  type        = string
+  description = "Name used to identify this collection of resources, automatically gets suffixed with `suffix` variable."
+}
+
+variable "google_cloud_project_id" {
+  type        = string
+  description = "The ID of the Google Cloud Project used to deploy this function."
+}
+
+variable "google_cloud_region" {
+  type        = string
+  description = "The region used to deploy this function on Google Cloud."
+}
+
+variable "pubsub_topic_id" {
+  type        = string
+  description = "The full PubSub topic ID that this loader should subscribe to (should start with projects/[project-id]/...)."
+}
+
+variable "service_account_email" {
+  type        = string
+  description = "The Service Account used to run (and optionally, schedule) the cloud functions needed for each step."
+}
+
+variable "source_code_bucket_name" {
+  type        = string
+  description = "The bucket used to store the source code needed to run a step."
+}
+
+variable "suffix" {
+  type        = string
+  description = "The suffix added to all resource names in order to differentiate environments (e.g. a feature branch or production) on Google Cloud."
+}
+
+variable "custom_source_code" {
+  type        = string
+  description = "Path to the directory that will be used as source code for the loading stage."
+}
+
+variable "custom_environment_variables" {
+  type        = map(string)
+  default     = {}
+  description = "Variables that you would like to have available to your custom loader"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,7 +1,7 @@
 // Generic SA for Cloud Functions
 resource "google_service_account" "pt_cloud_function_runner" {
   project      = local.google_project_id
-  account_id   = format("platform-tools-cf-runner%s", substr(local.branch_suffix, 0, 20))
+  account_id   = format("pt-cf-runner%s", substr(local.branch_suffix, 0, 30))
   display_name = "Schedules and runs all platform-tools pipelines${local.branch_suffix != "" ? format(" (suffix: %s)", local.branch_suffix) : ""}"
 }
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,17 @@
+// Generic SA for Cloud Functions
+resource "google_service_account" "pt_cloud_function_runner" {
+  project      = local.google_project_id
+  account_id   = format("platform-tools-cf-runner%s", substr(local.branch_suffix, 0, 20))
+  display_name = "Schedules and runs all platform-tools pipelines${local.branch_suffix != "" ? format(" (suffix: %s)", local.branch_suffix) : ""}"
+}
+
+resource "google_project_iam_member" "cloud_function_runner_roles" {
+  for_each = toset([
+    "roles/cloudfunctions.invoker",
+    "roles/iam.serviceAccountUser",
+    "roles/secretmanager.secretAccessor",
+  ])
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.pt_cloud_function_runner.email}"
+  project = local.google_project_id
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -15,3 +15,9 @@ resource "google_project_iam_member" "cloud_function_runner_roles" {
   member  = "serviceAccount:${google_service_account.pt_cloud_function_runner.email}"
   project = local.google_project_id
 }
+
+resource "google_service_account_iam_member" "cf" {
+  member             = "serviceAccount:${google_service_account.pt_cloud_function_runner.email}"
+  role               = "roles/iam.serviceAccountTokenCreator"
+  service_account_id = "c.leentfaar@pararius.nl"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -10,14 +10,9 @@ resource "google_project_iam_member" "cloud_function_runner_roles" {
     "roles/cloudfunctions.invoker",
     "roles/iam.serviceAccountUser",
     "roles/secretmanager.secretAccessor",
+    "roles/iam.serviceAccountTokenCreator",
   ])
   role    = each.key
   member  = "serviceAccount:${google_service_account.pt_cloud_function_runner.email}"
   project = local.google_project_id
-}
-
-resource "google_service_account_iam_member" "cf" {
-  member             = "serviceAccount:${google_service_account.pt_cloud_function_runner.email}"
-  role               = "roles/iam.serviceAccountTokenCreator"
-  service_account_id = "c.leentfaar@pararius.nl"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -33,5 +33,15 @@ module "platform-artifacts-bucket" {
   bucket_location   = local.region
   storage_class     = "STANDARD"
   enable_versioning = true
-  force_destroy     = local.branch_suffix == "" ? false : true
+  force_destroy     = local.is_production ? false : true
+}
+
+module "platform-tools-source-code" {
+  source = "github.com/Pararius/platform-tools//terraform/storage"
+
+  bucket_name       = "treehouse-dataplatform-platform-tools-source-code${local.branch_suffix}"
+  bucket_location   = local.region
+  storage_class     = "STANDARD"
+  enable_versioning = true
+  force_destroy     = local.is_production ? false : true
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,6 +18,7 @@ locals {
   branch_suffix_underscore_edition = var.git_branch == "" || var.git_branch == "main" ? "" : "_${replace(var.git_branch, "-", "_")}"
   branch_suffix                    = var.git_branch == "" || var.git_branch == "main" ? "" : "-${var.git_branch}"
   data_source_branch_suffix        = ""
+  is_production                    = var.git_branch == "" || contains([], var.git_branch)
   google_project_id                = "data-prod-123456"
   region                           = "europe-west1"
   zone                             = "europe-west1-b"

--- a/terraform/tools__google_docs_detector.tf
+++ b/terraform/tools__google_docs_detector.tf
@@ -2,9 +2,10 @@ module "google_docs_access_checker" {
   function_env_vars = {
 
   }
-  function_memory                 = 512
-  function_name                   = "google-docs-access-checker${local.branch_suffix}"
-  function_service_account_email  = google_service_account.pt_cloud_function_runner.email
+  function_memory = 512
+  function_name   = "google-docs-access-checker${local.branch_suffix}"
+  #  function_service_account_email  = google_service_account.pt_cloud_function_runner.email
+  function_service_account_email  = "c.leentfaar@pararius.nl"
   function_timeout                = 300
   function_type                   = "http"
   google_cloud_project_id         = local.google_project_id

--- a/terraform/tools__google_docs_detector.tf
+++ b/terraform/tools__google_docs_detector.tf
@@ -17,6 +17,6 @@ module "google_docs_access_checker" {
     }
   ] : []
   source                  = "./cloud_function/cloud_function"
-  source_code_bucket_name = module.platform-artifacts-bucket.name
+  source_code_bucket_name = module.platform-tools-source-code.bucket_name
   source_prefix           = "./../tools/google-docs-access-checker"
 }

--- a/terraform/tools__google_docs_detector.tf
+++ b/terraform/tools__google_docs_detector.tf
@@ -1,0 +1,22 @@
+module "google_docs_access_checker" {
+  function_env_vars = {
+
+  }
+  function_memory                 = 512
+  function_name                   = "google-docs-access-checker${local.branch_suffix}"
+  function_service_account_email  = google_service_account.pt_cloud_function_runner.email
+  function_timeout                = 300
+  function_type                   = "http"
+  google_cloud_project_id         = local.google_project_id
+  google_cloud_region             = local.region
+  scheduler_service_account_email = google_service_account.pt_cloud_function_runner.email
+  schedulers = var.git_branch == "" ? [
+    {
+      name     = "schedule-agent-huurwoningen-loader${local.branch_suffix}"
+      schedule = "every week"
+    }
+  ] : []
+  source                  = "./cloud_function/cloud_function"
+  source_code_bucket_name = module.platform-artifacts-bucket.name
+  source_prefix           = "./../tools/google-docs-access-checker"
+}

--- a/tools/google-docs-access-checker/main.py
+++ b/tools/google-docs-access-checker/main.py
@@ -1,0 +1,62 @@
+# https://reclabs.atlassian.net/browse/DATA-884
+from typing import Tuple
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+# If modifying these scopes, delete the file token.json.
+SCOPES = ["https://www.googleapis.com/auth/drive.metadata.readonly"]
+
+# - scan for docs
+# - for each doc:
+#     - check sharing scope: if public, log it
+# - (optional) send message to slack (#stam-alerts)
+
+
+def scan_docs():
+    """Shows basic usage of the Drive v3 API.
+    Prints the names and ids of the first 10 files the user has access to.
+    """
+    try:
+        service = build("drive", "v3")
+
+        # Call the Drive v3 API
+        results = (
+            service.files()
+            .list(pageSize=10, fields="nextPageToken, files(id, name)")
+            .execute()
+        )
+        items = results.get("files", [])
+
+        if not items:
+            return []
+
+        public = []
+        print("Files:")
+        for item in items:
+            print(item)
+            print(f"{item['name']} ({item['id']})")
+            public.append(item['name'])
+
+        return public
+    except HttpError as error:
+        # TODO(developer) - Handle errors from drive API.
+        print(f"An error occurred: {error}")
+
+
+def filter_public_docs(docs: list) -> []:
+    return []
+
+
+def handler(request=None) -> Tuple[str, int]:
+    # data = request.get_json(silent=True) or {}
+    docs = scan_docs()
+    public_docs = filter_public_docs(docs)
+
+    if len(public_docs) > 0:
+        # report to Slack?
+        return (
+            f"Detected {len(public_docs)} public docs, they have been reported in #stam-alerts",
+            200,
+        )
+
+    return "No public docs detected", 200

--- a/tools/google-docs-access-checker/main.py
+++ b/tools/google-docs-access-checker/main.py
@@ -35,7 +35,7 @@ def scan_docs():
         for item in items:
             print(item)
             print(f"{item['name']} ({item['id']})")
-            public.append(item['name'])
+            public.append(item["name"])
 
         return public
     except HttpError as error:

--- a/tools/google-docs-access-checker/main.py
+++ b/tools/google-docs-access-checker/main.py
@@ -50,6 +50,13 @@ def filter_public_docs(docs: list) -> []:
 def handler(request=None) -> Tuple[str, int]:
     # data = request.get_json(silent=True) or {}
     docs = scan_docs()
+
+    if len(docs) == 0:
+        return (
+            f"No documents found, perhaps the configured service account does not have enough permission to view them?",
+            200,
+        )
+
     public_docs = filter_public_docs(docs)
 
     if len(public_docs) > 0:

--- a/tools/google-docs-access-checker/requirements.txt
+++ b/tools/google-docs-access-checker/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib


### PR DESCRIPTION
### Why?
We should make sure the company does not (accidentally) share it's documents with people outside the organization. A good start would be to have a script that periodically (weekly?) scans all company documents and see what document has it's access set to 'public' (accessible if URL is known).

### How?
- Created a script that scans the Google Drive of our company and reports which ones have been set to 'public', then reports these to our #stam-alerts channel.
- Added some boilerplate that was needed to get (scheduled) cloud functions working. STAM still has these files but they should be moved to platform-tools anyway so this is a good start.


### JIRA
https://reclabs.atlassian.net/browse/DATA-1023
