### PR TITLE
Added query_string_to_json function

### DIFF
--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -252,3 +252,23 @@ resource "google_bigquery_routine" "parse_dutch_date" {
   ) AS STRING)
 EOF
 }
+
+resource "google_bigquery_routine" "query_string_to_json" {
+  dataset_id   = local.routines_dataset
+  routine_id   = "query_string_to_json${local.branch_suffix_underscore_edition}"
+  routine_type = "SCALAR_FUNCTION"
+  language     = "JAVASCRIPT"
+  arguments {
+    name      = "qs"
+    data_type = "{\"typeKind\" :  \"STRING\"}"
+  }
+  definition_body = <<EOF
+if (qs.charAt(0) == '?') {
+  qs = qs.substring(1)
+}
+
+return JSON.stringify(JSON.parse('{"' + decodeURI(qs.replace(/&/g, "\",\"").replace(/=/g,"\":\"")) + '"}'))
+EOF
+
+  return_type = "{\"typeKind\": \"STRING\"}"
+}


### PR DESCRIPTION
### Why?
Currently we use query *strings* to check for certain referrers. This is unstable though as these checking patterns can easily overlap, for example:

given a query string like `?foo=bar&code=123` and a query string like `?foo=bar&postal_code=1234AB`
and let's say the referrer is identifiable by a `code` parameter, normally we'd do 
`WHERE query_string LIKE '%code=%`, but that would match both `code` and `postal_code`.

This is just one example, there are many (infinite) possiblities for this to happen as the `LIKE` does not take into account parameter separators like `?` and `&`, depending on where in the string the parameter occurs.

We could force ourselves to make very complex regex patterns for this but I think it will be much easier to just write a query like `WHERE query_parameters.code IS NOT NULL`


### How?
*Describe how this PR will fix the problem mentioned above. This is used by reviewers to determine if the correct solution was chosen and was implemented correctly*

### JIRA
*If there is a JIRA issue related to this change, add a link to it here*
