### PR TITLE
Created array_distinct function to easily get only the unique values from an array

### DIFF
--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -252,3 +252,24 @@ resource "google_bigquery_routine" "parse_dutch_date" {
   ) AS STRING)
 EOF
 }
+
+resource "google_bigquery_routine" "array_distinct" {
+  dataset_id      = local.routines_dataset
+  definition_body = <<EOF
+(
+  SELECT ARRAY_AGG(a.b)
+  FROM (SELECT DISTINCT * FROM UNNEST(value) b) a
+)
+EOF
+  language        = "SQL"
+  project         = local.google_project_id
+  return_type     = "{\"typeKind\": \"ARRAY<STRING>\"}"
+  routine_id      = "array_distinct${local.branch_suffix_underscore_edition}"
+  routine_type    = "SCALAR_FUNCTION"
+
+  arguments {
+    name          = "value"
+    argument_kind = "FIXED_TYPE"
+    data_type     = "{\"typeKind\" :  \"ARRAY<STRING>\"}"
+  }
+}

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -268,8 +268,8 @@ EOF
   routine_type    = "SCALAR_FUNCTION"
 
   arguments {
-    name          = "value"
     argument_kind = "FIXED_TYPE"
-    data_type     = "{\"typeKind\": \"ARRAY<STRING>\"}"
+    data_type     = "{\"typeKind\": \"ARRAY\", \"arrayElementType\": {\"typeKind\": \"STRING\"}}"
+    name          = "value"
   }
 }

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -270,6 +270,6 @@ EOF
   arguments {
     name          = "value"
     argument_kind = "FIXED_TYPE"
-    data_type     = "{\"typeKind\": \"ARRAY\"}"
+    data_type     = "{\"typeKind\": \"ARRAY<STRING>\"}"
   }
 }

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -263,13 +263,13 @@ resource "google_bigquery_routine" "array_distinct" {
 EOF
   language        = "SQL"
   project         = local.google_project_id
-  return_type     = "{\"typeKind\": \"ARRAY<STRING>\"}"
+  return_type     = "{\"typeKind\": \"ARRAY\"}"
   routine_id      = "array_distinct${local.branch_suffix_underscore_edition}"
   routine_type    = "SCALAR_FUNCTION"
 
   arguments {
     name          = "value"
     argument_kind = "FIXED_TYPE"
-    data_type     = "{\"typeKind\" :  \"ARRAY<STRING>\"}"
+    data_type     = "{\"typeKind\": \"ARRAY\"}"
   }
 }

--- a/terraform/routines.tf
+++ b/terraform/routines.tf
@@ -263,7 +263,7 @@ resource "google_bigquery_routine" "array_distinct" {
 EOF
   language        = "SQL"
   project         = local.google_project_id
-  return_type     = "{\"typeKind\": \"ARRAY\"}"
+  return_type     = "{\"typeKind\": \"ARRAY\", \"arrayElementType\": {\"typeKind\": \"STRING\"}}"
   routine_id      = "array_distinct${local.branch_suffix_underscore_edition}"
   routine_type    = "SCALAR_FUNCTION"
 


### PR DESCRIPTION
### Why?
Needed a quick and easy way to only get unique values from an array.

### How?
BigQuery does not really provide with an easy of doing this without using `UNNEST` which is costly especially on larger datasets which is what I'm going to use it on.

source: https://feralcat.xyz/blog/2022/03/16/removing-duplicate-elements-from-an-array-in-bigquery/

### JIRA
n/a
